### PR TITLE
[SETTINGS] set QCODE_MISSING_VOC to "created"

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
 honcho==1.0.1
 newrelic>=2.66,<2.67
--e git+git://github.com/superdesk/superdesk-core.git@0298eca#egg=Superdesk-Core
+-e git+git://github.com/superdesk/superdesk-core.git@ed7e723#egg=Superdesk-Core

--- a/server/settings.py
+++ b/server/settings.py
@@ -79,3 +79,4 @@ SCHEMA = {
         'keywords': {},
     }
 }
+QCODE_MISSING_VOC = "create"


### PR DESCRIPTION
This new value will create missing vocabularies for STT proprietary
metadata when they are parsed.

SDESK-3507 STTNHUB-14 STTNHUB-18