### PR TITLE
[STTNHUB-339] fix: Store content headline into new coverage slugline

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -62,62 +62,16 @@
             }
         },
         "@babel/parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
-            "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg=="
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+            "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg=="
         },
         "@babel/runtime": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-            "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+            "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
             "requires": {
                 "regenerator-runtime": "^0.14.0"
-            }
-        },
-        "@material-ui/lab": {
-            "version": "4.0.0-alpha.61",
-            "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
-            "integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
-            "requires": {
-                "@babel/runtime": "^7.4.4",
-                "@material-ui/utils": "^4.11.3",
-                "clsx": "^1.0.4",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.0 || ^17.0.0"
-            },
-            "dependencies": {
-                "prop-types": {
-                    "version": "15.8.1",
-                    "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-                    "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-                    "requires": {
-                        "loose-envify": "^1.4.0",
-                        "object-assign": "^4.1.1",
-                        "react-is": "^16.13.1"
-                    }
-                }
-            }
-        },
-        "@material-ui/utils": {
-            "version": "4.11.3",
-            "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
-            "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
-            "requires": {
-                "@babel/runtime": "^7.4.4",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.0 || ^17.0.0"
-            },
-            "dependencies": {
-                "prop-types": {
-                    "version": "15.8.1",
-                    "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-                    "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-                    "requires": {
-                        "loose-envify": "^1.4.0",
-                        "object-assign": "^4.1.1",
-                        "react-is": "^16.13.1"
-                    }
-                }
             }
         },
         "@metadata/exif": {
@@ -158,9 +112,9 @@
             "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
         },
         "@superdesk/build-tools": {
-            "version": "1.0.18",
-            "resolved": "https://registry.npmjs.org/@superdesk/build-tools/-/build-tools-1.0.18.tgz",
-            "integrity": "sha512-1R2zT+dAJs1G/cEJgK72eNwetibfdsYRxURM3cjGM+cvdAwg3lKJxDxSWqCjWH3NT30uDTf1EJg6JQhwl0PmeA==",
+            "version": "1.0.19",
+            "resolved": "https://registry.npmjs.org/@superdesk/build-tools/-/build-tools-1.0.19.tgz",
+            "integrity": "sha512-ctL0/dZCqWcoxvcCMFLza4aLXP+wfszwkz/HMv25+fEiAJ6oTc33VpmnNcHfEClXoMupig6l1UcMFt98ZqVjOQ==",
             "dev": true,
             "requires": {
                 "commander": "^7.2.0",
@@ -193,7 +147,7 @@
                 "cssesc": {
                     "version": "0.1.0",
                     "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-                    "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+                    "integrity": "sha512-72avb2vCIsNDBlSMYuxt2Cmg6Z4TTGqifblGs7IXGihhuEzghCb9Pu1Y6vzVPLC03OTXnAKsTm92ChZd4uzVBQ==",
                     "dev": true
                 },
                 "glob": {
@@ -208,15 +162,6 @@
                         "minimatch": "^3.0.4",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "rimraf": {
@@ -328,6 +273,16 @@
             "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
             "requires": {
                 "@types/node": "*"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "20.12.7",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+                    "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+                    "requires": {
+                        "undici-types": "~5.26.4"
+                    }
+                }
             }
         },
         "@types/draft-js": {
@@ -504,12 +459,12 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "accepts": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-            "integrity": "sha512-R190A3EzrS4huFOVZajhXCYZt5p5yrkaQOB4nsWzfth0cYaDcSN5J86l58FJ1dt7igp37fB/QhnuFkGAJmr+eg==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
             "requires": {
-                "mime-types": "~2.1.6",
-                "negotiator": "0.5.3"
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
             }
         },
         "acorn": {
@@ -536,14 +491,6 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
-        },
-        "active-x-obfuscator": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
-            "integrity": "sha512-8gdEZinfLSCfAUulETDth4ZSIDPSchiPgm5PLrXQC6BANf1YFEDrPPM2MdK2zcekMROwtM667QFuYw/H6ZV06Q==",
-            "requires": {
-                "zeparser": "0.0.5"
-            }
         },
         "airbnb-prop-types": {
             "version": "2.16.0",
@@ -597,16 +544,6 @@
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
                 "repeat-string": "^1.5.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
             }
         },
         "alphanum-sort": {
@@ -639,20 +576,12 @@
             "from": "github:superdesk/angular-embed#d75968e"
         },
         "angular-embedly": {
-            "version": "github:Urigo/angular-embedly#e48ff27af8bd702f1cefea6119c863df9b0e6042",
-            "from": "github:Urigo/angular-embedly#0.0.8",
-            "requires": {
-                "gulp": "~3.8.2",
-                "gulp-concat": "~2.2.0",
-                "gulp-uglify": "~0.3.1",
-                "karma": "~0.12.16",
-                "karma-chrome-launcher": "~0.1.4",
-                "karma-jasmine": "~0.1.5"
-            }
+            "version": "github:superdesk/angular-embedly#7aedd3bb0d359aeec0f6de2c6471c5842435d7ad",
+            "from": "github:superdesk/angular-embedly#master"
         },
         "angular-gettext": {
-            "version": "github:tomaskikutis/angular-gettext#5615f0058ecf7f4aeeb7ec1a24e2cff4426fffa6",
-            "from": "github:tomaskikutis/angular-gettext#master"
+            "version": "github:superdesk/angular-gettext#5615f0058ecf7f4aeeb7ec1a24e2cff4426fffa6",
+            "from": "github:superdesk/angular-gettext#master"
         },
         "angular-gettext-tools": {
             "version": "2.5.3",
@@ -707,14 +636,6 @@
                 "type-fest": "^0.21.3"
             }
         },
-        "ansi-gray": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-            "integrity": "sha512-HrgGIZUl8h2EHuZaU9hTR/cU5nhKxpVE1V6kdGsQ8e4zirElJ5fvtfc8N7Q1oq1aatO275i8pUFUCpNWCAnVWw==",
-            "requires": {
-                "ansi-wrap": "0.1.0"
-            }
-        },
         "ansi-html": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
@@ -730,111 +651,20 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
         },
-        "ansi-wrap": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw=="
-        },
         "anymatch": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-            "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "optional": true,
             "requires": {
-                "micromatch": "^2.1.5",
-                "normalize-path": "^2.0.0"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg=="
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww=="
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
-                }
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
             }
         },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-        },
-        "archy": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
         },
         "are-we-there-yet": {
             "version": "1.1.7",
@@ -863,6 +693,11 @@
                         "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
                     }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 },
                 "string_decoder": {
                     "version": "1.1.1",
@@ -911,11 +746,6 @@
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
             "integrity": "sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ=="
         },
-        "array-each": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-            "integrity": "sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA=="
-        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -938,11 +768,6 @@
                 "get-intrinsic": "^1.2.4",
                 "is-string": "^1.0.7"
             }
-        },
-        "array-slice": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
         },
         "array-union": {
             "version": "2.1.0",
@@ -1090,9 +915,12 @@
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
         },
         "async": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+            "requires": {
+                "lodash": "^4.17.14"
+            }
         },
         "async-each": {
             "version": "1.0.6",
@@ -1186,18 +1014,6 @@
                 "js-tokens": "^3.0.2"
             },
             "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
                 "js-tokens": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1227,9 +1043,9 @@
             }
         },
         "balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+            "integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg=="
         },
         "base": {
             "version": "0.11.2",
@@ -1269,30 +1085,10 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
             "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
-        "base64-url": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-            "integrity": "sha512-V8E0l1jyyeSSS9R+J9oljx5eq2rqzClInuwaPcyuv0Mm3ViI/3/rcc4rCEO8i4eQ4I0O0FAGYDA2i5xWHHPhzg=="
-        },
-        "base64id": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-            "integrity": "sha512-DSjtfjhAsHl9J4OJj7e4+toV2zqxJrGwVd3CLlsCp8QmicvOn7irG0Mb8brOc/nur3SdO8lIbNlY1s1ZDJdUKQ=="
-        },
-        "basic-auth": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
-            "integrity": "sha512-uvq3I/zC5TmG0WZJDzsXzIytU9GiiSq23Gl27Dq9sV81JTfPfQhtdADECP1DJZeJoZPuYU0Y81hWC5y/dOR+Yw=="
-        },
-        "basic-auth-connect": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-            "integrity": "sha512-kiV+/DTgVro4aZifY/hwRwALBISViL5NP4aReaR2EVJEObpbUBHIkdJh/YpcoEiYt7nBodZ6U2ajZeZvSxUCCg=="
-        },
         "batch": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-            "integrity": "sha512-aQgHPLH2DHpFTpBl5/GiVdNzHEqsLCSs1RiPvqkKP1+7RkNJlv71kL8/KXmvvaLqoZ7ylmvqkZhLjjAoRz8Xgw=="
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -1302,34 +1098,21 @@
                 "tweetnacl": "^0.14.3"
             }
         },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha512-3vqtKL1N45I5dV0RdssXZG7X6pCqQrWPNOlBPZPrd+QkE2HEhR57Z04m0KtpbsZH73j+a3F8UD1TQnn+ExTvIA=="
-        },
         "big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
             "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
         },
         "binary-extensions": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "optional": true
         },
         "binary-search": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
             "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
-        },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "optional": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
         },
         "block-stream": {
             "version": "0.0.9",
@@ -1350,34 +1133,57 @@
             "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
         },
         "body-parser": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
-            "integrity": "sha512-ypX8/9uws2W+CjPp3QMmz1qklzlhRBknQve22Y+WFecHql+qDFfG+VVNX7sooA4Q3+2fdq4ZZj6Xr07gA90RZg==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "requires": {
-                "bytes": "2.1.0",
-                "content-type": "~1.0.1",
-                "debug": "~2.2.0",
-                "depd": "~1.0.1",
-                "http-errors": "~1.3.1",
-                "iconv-lite": "0.4.11",
-                "on-finished": "~2.3.0",
-                "qs": "4.0.0",
-                "raw-body": "~2.1.2",
-                "type-is": "~1.6.6"
+                "bytes": "3.1.2",
+                "content-type": "~1.0.5",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "on-finished": "2.4.1",
+                "qs": "6.11.0",
+                "raw-body": "2.5.2",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
             },
             "dependencies": {
+                "bytes": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+                },
                 "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "requires": {
-                        "ms": "0.7.1"
+                        "ms": "2.0.0"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                },
+                "qs": {
+                    "version": "6.11.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+                    "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
                 }
             }
         },
@@ -1392,21 +1198,6 @@
                 "dns-txt": "^2.0.2",
                 "multicast-dns": "^6.0.1",
                 "multicast-dns-service-types": "^1.1.0"
-            },
-            "dependencies": {
-                "deep-equal": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-                    "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-                    "requires": {
-                        "is-arguments": "^1.1.1",
-                        "is-date-object": "^1.0.5",
-                        "is-regex": "^1.1.4",
-                        "object-is": "^1.1.5",
-                        "object-keys": "^1.1.1",
-                        "regexp.prototype.flags": "^1.5.1"
-                    }
-                }
             }
         },
         "boolbase": {
@@ -1426,6 +1217,13 @@
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+                    "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+                }
             }
         },
         "braces": {
@@ -1536,11 +1334,6 @@
                         }
                     }
                 },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                },
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1608,9 +1401,9 @@
             "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
         },
         "bytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-            "integrity": "sha512-k9VSlRfRi5JYyQWMylSOgjld96ta1qaQUIvmn+na0BzViclH04PBumewv4z5aeXNkn6Z/gAN5FtPeBLvV20F9w=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
         },
         "cache-base": {
             "version": "1.0.1",
@@ -1680,9 +1473,9 @@
             }
         },
         "caniuse-db": {
-            "version": "1.0.30001600",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001600.tgz",
-            "integrity": "sha512-BS+RAD1DggiDlE2KaBUWKsMDuVmmh3hCM5LI0OW25mGlPttGLeOjDUa1DmZvJVFCXvtshY4BTyFgv31eFTLg8g=="
+            "version": "1.0.30001611",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001611.tgz",
+            "integrity": "sha512-9IOx+mNYnYJDxYFeGJFgt3scvLXZguxJlHmZFLTtyYkJVMRwIUk2kGH29dYM/FPOZe38uZGvgYtJFNL3Ym2o2A=="
         },
         "caseless": {
             "version": "0.12.0",
@@ -1699,48 +1492,15 @@
             }
         },
         "chalk": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-            "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
             "requires": {
-                "ansi-styles": "^1.1.0",
-                "escape-string-regexp": "^1.0.0",
-                "has-ansi": "^0.1.0",
-                "strip-ansi": "^0.3.0",
-                "supports-color": "^0.2.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                    "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA=="
-                },
-                "ansi-styles": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-                    "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA=="
-                },
-                "has-ansi": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                    "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
-                    "requires": {
-                        "ansi-regex": "^0.2.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                    "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
-                    "requires": {
-                        "ansi-regex": "^0.2.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-                    "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA=="
-                }
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "change-case": {
@@ -1820,13 +1580,6 @@
                 "lodash.reduce": "^4.4.0",
                 "lodash.reject": "^4.4.0",
                 "lodash.some": "^4.4.0"
-            },
-            "dependencies": {
-                "lodash.defaults": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-                    "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
-                }
             }
         },
         "cheerio-select": {
@@ -1908,42 +1661,19 @@
             }
         },
         "chokidar": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-            "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "optional": true,
             "requires": {
-                "anymatch": "^1.3.0",
-                "async-each": "^1.0.0",
-                "fsevents": "^1.0.0",
-                "glob-parent": "^2.0.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^2.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
-                    "requires": {
-                        "is-glob": "^2.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww=="
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
             }
         },
         "ci-info": {
@@ -1966,20 +1696,6 @@
             "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "requires": {
                 "chalk": "^1.1.3"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                }
             }
         },
         "class-utils": {
@@ -2056,13 +1772,6 @@
                 "center-align": "^0.1.1",
                 "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "0.0.2",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                    "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
-                }
             }
         },
         "clone": {
@@ -2079,27 +1788,7 @@
                 "is-plain-object": "^2.0.1",
                 "kind-of": "^3.2.2",
                 "shallow-clone": "^0.1.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
             }
-        },
-        "clone-stats": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha512-dhUqc57gSMCo6TX85FLfe51eC/s+Im2MLkAgJwfaRRexR2tA4dd3eLEW4L6efzHc2iNorrRRXITifnDLlRrhaA=="
-        },
-        "clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
         },
         "co": {
             "version": "4.6.0",
@@ -2164,11 +1853,6 @@
                 "color-name": "^1.0.0"
             }
         },
-        "color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-        },
         "colormin": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
@@ -2180,9 +1864,9 @@
             }
         },
         "colors": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w=="
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -2193,9 +1877,12 @@
             }
         },
         "commander": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-            "integrity": "sha512-J2wnb6TKniXNOtoHS8TSrG9IOQluPrsmyAJ8oCUJOBmv+uLBCyPYAZkD2jFvw2DCzIXNnISIM01NIvr35TkBMQ=="
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
+            "requires": {
+                "graceful-readlink": ">= 1.0.0"
+            }
         },
         "component-emitter": {
             "version": "1.3.1",
@@ -2211,121 +1898,48 @@
             }
         },
         "compression": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
-            "integrity": "sha512-+2fE8M8+Oe0kAlbMPz6UinaaH/HaGf+c5HlWRyYtPga/PHKxStJJKTU4xca8StY0JQ78L2kJaslpgSzCKgHaxQ==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
             "requires": {
-                "accepts": "~1.2.12",
-                "bytes": "2.1.0",
-                "compressible": "~2.0.5",
-                "debug": "~2.2.0",
-                "on-headers": "~1.0.0",
-                "vary": "~1.0.1"
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "requires": {
-                        "ms": "0.7.1"
+                        "ms": "2.0.0"
                     }
                 },
                 "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 }
             }
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "connect": {
-            "version": "2.30.2",
-            "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
-            "integrity": "sha512-eY4YHls5bz/g6h9Q8B/aVkS6D7+TRiRlI3ksuruv3yc2rLbTG7HB/7T/CoZsuVH5e2i3S9J+2eARV5o7GIYq8Q==",
-            "requires": {
-                "basic-auth-connect": "1.0.0",
-                "body-parser": "~1.13.3",
-                "bytes": "2.1.0",
-                "compression": "~1.5.2",
-                "connect-timeout": "~1.6.2",
-                "content-type": "~1.0.1",
-                "cookie": "0.1.3",
-                "cookie-parser": "~1.3.5",
-                "cookie-signature": "1.0.6",
-                "csurf": "~1.8.3",
-                "debug": "~2.2.0",
-                "depd": "~1.0.1",
-                "errorhandler": "~1.4.2",
-                "express-session": "~1.11.3",
-                "finalhandler": "0.4.0",
-                "fresh": "0.3.0",
-                "http-errors": "~1.3.1",
-                "method-override": "~2.3.5",
-                "morgan": "~1.6.1",
-                "multiparty": "3.3.2",
-                "on-headers": "~1.0.0",
-                "parseurl": "~1.3.0",
-                "pause": "0.1.0",
-                "qs": "4.0.0",
-                "response-time": "~2.3.1",
-                "serve-favicon": "~2.3.0",
-                "serve-index": "~1.7.2",
-                "serve-static": "~1.10.0",
-                "type-is": "~1.6.6",
-                "utils-merge": "1.0.0",
-                "vhost": "~3.0.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
-                    "requires": {
-                        "ms": "0.7.1"
-                    }
-                },
-                "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
-                }
-            }
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "connect-history-api-fallback": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
             "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
-        },
-        "connect-timeout": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
-            "integrity": "sha512-qIFt3Ja6gRuJtVoWhPa5FtOO8ERs0MfW/QkmQ0vjrAL78otrkxe8w/qjTAgU/T1W/jH5qeZXJHilmOPKNTiEQw==",
-            "requires": {
-                "debug": "~2.2.0",
-                "http-errors": "~1.3.1",
-                "ms": "0.7.1",
-                "on-headers": "~1.0.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
-                    "requires": {
-                        "ms": "0.7.1"
-                    }
-                },
-                "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
-                }
-            }
         },
         "console-browserify": {
             "version": "1.2.0",
@@ -2357,13 +1971,6 @@
             "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
             "requires": {
                 "safe-buffer": "5.2.1"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                }
             }
         },
         "content-type": {
@@ -2377,18 +1984,9 @@
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
         },
         "cookie": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-            "integrity": "sha512-mWkFhcL+HVG1KjeCjEBVJJ7s4sAGMLiBDFSDs4bzzvgLZt7rW8BhP6XV/8b1+pNvx/skd3yYxPuaF3Z6LlQzyw=="
-        },
-        "cookie-parser": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
-            "integrity": "sha512-YN/8nzPcK5o6Op4MIzAd4H4qUal5+3UaMhVIeaafFYL0pKvBQA/9Yhzo7ZwvBpjdGshsiTAb1+FC37M6RdPDFg==",
-            "requires": {
-                "cookie": "0.1.3",
-                "cookie-signature": "1.0.6"
-            }
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
         },
         "cookie-signature": {
             "version": "1.0.6",
@@ -2409,11 +2007,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-        },
-        "crc": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
-            "integrity": "sha512-QCx3z7FOZbJrapsnewTkh1Hxh6PHV61SRHbx6Q65Uih3y0kfIj+dDGI3uQ4Q1DLKOILyvpZxvJpoKPrxathpCg=="
         },
         "create-ecdh": {
             "version": "4.0.4",
@@ -2525,16 +2118,6 @@
                     "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
                     "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
                 }
-            }
-        },
-        "csrf": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
-            "integrity": "sha512-3q1ocniLMgk9nHHEt/I/JsN9IfiGjgp6MHgYNT7+CPmQvi5DF6qzenXnZSH6f9Qaa+4DhmUDJa8SgFZ+OFf9Qg==",
-            "requires": {
-                "rndm": "1.2.0",
-                "tsscmp": "1.0.5",
-                "uid-safe": "2.1.4"
             }
         },
         "css": {
@@ -2676,20 +2259,9 @@
             }
         },
         "csstype": {
-            "version": "2.6.21",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-            "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
-        },
-        "csurf": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
-            "integrity": "sha512-p2NJ9fGOn5HCaV9jAOBCSjIGMRMrpm9/yDswD0bFi7zQv1ifDufIKI5nem9RmhMsH6jVD6Sx6vs57hnivvkJJw==",
-            "requires": {
-                "cookie": "0.1.3",
-                "cookie-signature": "1.0.6",
-                "csrf": "~3.0.0",
-                "http-errors": "~1.3.1"
-            }
+            "version": "2.6.17",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+            "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
         },
         "currently-unhandled": {
             "version": "0.4.1",
@@ -2760,9 +2332,13 @@
             }
         },
         "dateformat": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-            "integrity": "sha512-GODcnWq3YGoTnygPfi02ygEiRxqUxpJwuRHjdhJYuxpcZmDq4rjBiXYmbCCzStxo176ixfLT6i4NPwQooRySnw=="
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "integrity": "sha512-5sFRfAAmbHdIts+eKjR9kYJoF0ViCMVX9yqLu5A7S/v+nd077KgCITOMiirmyCBiZpKLDXbBOkYm6tu7rX/TKg==",
+            "requires": {
+                "get-stdin": "^4.0.1",
+                "meow": "^3.3.0"
+            }
         },
         "debug": {
             "version": "4.3.4",
@@ -2788,35 +2364,16 @@
             "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug=="
         },
         "deep-equal": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+            "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
             "requires": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.5",
-                "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.2",
                 "is-arguments": "^1.1.1",
-                "is-array-buffer": "^3.0.2",
                 "is-date-object": "^1.0.5",
                 "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "isarray": "^2.0.5",
                 "object-is": "^1.1.5",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.13"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-                }
+                "regexp.prototype.flags": "^1.5.1"
             }
         },
         "deep-for-each": {
@@ -2831,19 +2388,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
-        },
-        "deepmerge": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.10.tgz",
-            "integrity": "sha512-u75aE0uAUogoo2u7PIN44vUfITrmtABDgy58XY1U9JZpr/2Ghhib8Y/w0Btot3tgSXNZL4iy9ROMsQ3P0dhYvw=="
-        },
-        "defaults": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-            "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-            "requires": {
-                "clone": "^1.0.2"
-            }
         },
         "define-data-property": {
             "version": "1.1.4",
@@ -2911,19 +2455,6 @@
                         "array-uniq": "^1.0.1"
                     }
                 },
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
                 "globby": {
                     "version": "6.1.0",
                     "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -2941,14 +2472,6 @@
                             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
                         }
-                    }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "pify": {
@@ -2969,14 +2492,9 @@
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
         },
         "depd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-            "integrity": "sha512-OEWAMbCkK9IWQ8pfTvHBhCSqHgR+sk5pbiYqq0FqfARG4Cy+cRsCbITx6wh5pcsmfBPiJAcbd98tfdz5fnBbag=="
-        },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha512-BRACtc6B1mJe2J2mruHFqHWrtLy0Qppu/7LKdqWH3o/9j1L/1phPUaQV+2S3H8ZDW0k6h+NEOKcHBDRikWLiOA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         },
         "des.js": {
             "version": "1.1.0",
@@ -2988,24 +2506,14 @@
             }
         },
         "destroy": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-            "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
-        },
-        "detect-file": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-            "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q=="
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
         },
         "detect-node": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
-        },
-        "di": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-            "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA=="
         },
         "diff-match-patch": {
             "version": "1.0.0",
@@ -3066,7 +2574,7 @@
         },
         "docs-soap": {
             "version": "github:superdesk/docs-soap#9f51d082fd4bdcf80a56f51e5334c45fc6baa114",
-            "from": "github:superdesk/docs-soap#master"
+            "from": "github:superdesk/docs-soap#v1"
         },
         "doctrine": {
             "version": "3.0.0",
@@ -3182,14 +2690,6 @@
             "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.4.1.tgz",
             "integrity": "sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg=="
         },
-        "duplexer2": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
-            "requires": {
-                "readable-stream": "~1.1.9"
-            }
-        },
         "each-async": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz",
@@ -3235,9 +2735,9 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "electron-to-chromium": {
-            "version": "1.4.717",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz",
-            "integrity": "sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A=="
+            "version": "1.4.743",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.743.tgz",
+            "integrity": "sha512-AYgFmGUanfwZd4QmlGl9KBjoHRvJi6FUnbmfSr6NUk2JKCdHRHpljFGgxLp7L5h0p7uANrLzv0OgHo4TaCk4gA=="
         },
         "elliptic": {
             "version": "6.5.5",
@@ -3281,24 +2781,6 @@
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
             "requires": {
                 "iconv-lite": "^0.6.2"
-            },
-            "dependencies": {
-                "iconv-lite": {
-                    "version": "0.6.3",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3.0.0"
-                    }
-                }
-            }
-        },
-        "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha512-go5TQkd0YRXYhX+Lc3UrXkoKU5j+m72jEP5lHWr2Nh82L8wfZtH8toKgcg4T10o23ELIMGXQdwCbl+qAXIPDrw==",
-            "requires": {
-                "once": "~1.3.0"
             }
         },
         "enhanced-resolve": {
@@ -3310,13 +2792,6 @@
                 "memory-fs": "^0.4.0",
                 "object-assign": "^4.0.1",
                 "tapable": "^0.2.7"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                }
             }
         },
         "entities": {
@@ -3415,11 +2890,6 @@
                         "domutils": "^3.0.1",
                         "entities": "^4.4.0"
                     }
-                },
-                "lodash.escape": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-                    "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
                 }
             }
         },
@@ -3517,35 +2987,10 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-        "errorhandler": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
-            "integrity": "sha512-pp1hk9sZBq4Bj/e/Cl84fJ3cYiQDFZk3prp7jrurUbPGOlY7zA2OubjhhEAWuUb8VNTFIkGwoby7Uq6YpicfvQ==",
-            "requires": {
-                "accepts": "~1.3.0",
-                "escape-html": "~1.0.3"
-            },
-            "dependencies": {
-                "accepts": {
-                    "version": "1.3.8",
-                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-                    "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-                    "requires": {
-                        "mime-types": "~2.1.34",
-                        "negotiator": "0.6.3"
-                    }
-                },
-                "negotiator": {
-                    "version": "0.6.3",
-                    "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-                    "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-                }
-            }
-        },
         "es-abstract": {
-            "version": "1.23.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
-            "integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
+            "version": "1.23.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+            "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
             "requires": {
                 "array-buffer-byte-length": "^1.0.1",
                 "arraybuffer.prototype.slice": "^1.0.3",
@@ -3586,11 +3031,11 @@
                 "safe-regex-test": "^1.0.3",
                 "string.prototype.trim": "^1.2.9",
                 "string.prototype.trimend": "^1.0.8",
-                "string.prototype.trimstart": "^1.0.7",
+                "string.prototype.trimstart": "^1.0.8",
                 "typed-array-buffer": "^1.0.2",
                 "typed-array-byte-length": "^1.0.1",
                 "typed-array-byte-offset": "^1.0.2",
-                "typed-array-length": "^1.0.5",
+                "typed-array-length": "^1.0.6",
                 "unbox-primitive": "^1.0.2",
                 "which-typed-array": "^1.1.15"
             }
@@ -3612,29 +3057,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-        },
-        "es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-                }
-            }
         },
         "es-object-atoms": {
             "version": "1.0.0",
@@ -3865,14 +3287,6 @@
                         "esprima": "^4.0.0"
                     }
                 },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
                 "semver": {
                     "version": "6.3.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4035,9 +3449,9 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
         },
         "etag": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-            "integrity": "sha512-Mbv5pNpLNPrm1b4rzZlZlfTRpdDr31oiD43N362sIyvSWVNu5Du33EcJGzvEV4YdYLuENB1HzND907cQkFmXNw=="
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
         },
         "event-emitter": {
             "version": "0.3.5",
@@ -4210,23 +3624,7 @@
                     "requires": {
                         "isarray": "1.0.0"
                     }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
                 }
-            }
-        },
-        "expand-tilde": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-            "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
-            "requires": {
-                "homedir-polyfill": "^1.0.1"
             }
         },
         "express": {
@@ -4267,48 +3665,10 @@
                 "vary": "~1.1.2"
             },
             "dependencies": {
-                "accepts": {
-                    "version": "1.3.8",
-                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-                    "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-                    "requires": {
-                        "mime-types": "~2.1.34",
-                        "negotiator": "0.6.3"
-                    }
-                },
                 "array-flatten": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
                     "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-                },
-                "body-parser": {
-                    "version": "1.20.2",
-                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-                    "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-                    "requires": {
-                        "bytes": "3.1.2",
-                        "content-type": "~1.0.5",
-                        "debug": "2.6.9",
-                        "depd": "2.0.0",
-                        "destroy": "1.2.0",
-                        "http-errors": "2.0.0",
-                        "iconv-lite": "0.4.24",
-                        "on-finished": "2.4.1",
-                        "qs": "6.11.0",
-                        "raw-body": "2.5.2",
-                        "type-is": "~1.6.18",
-                        "unpipe": "1.0.0"
-                    }
-                },
-                "bytes": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-                },
-                "cookie": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-                    "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
                 },
                 "debug": {
                     "version": "2.6.9",
@@ -4318,77 +3678,10 @@
                         "ms": "2.0.0"
                     }
                 },
-                "depd": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-                    "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-                },
-                "destroy": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-                    "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
-                },
-                "etag": {
-                    "version": "1.8.1",
-                    "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-                    "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-                },
-                "finalhandler": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-                    "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
-                    "requires": {
-                        "debug": "2.6.9",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "on-finished": "2.4.1",
-                        "parseurl": "~1.3.3",
-                        "statuses": "2.0.1",
-                        "unpipe": "~1.0.0"
-                    }
-                },
-                "fresh": {
-                    "version": "0.5.2",
-                    "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-                    "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
-                },
-                "http-errors": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-                    "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-                    "requires": {
-                        "depd": "2.0.0",
-                        "inherits": "2.0.4",
-                        "setprototypeof": "1.2.0",
-                        "statuses": "2.0.1",
-                        "toidentifier": "1.0.1"
-                    }
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-                },
-                "negotiator": {
-                    "version": "0.6.3",
-                    "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-                    "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-                },
-                "on-finished": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-                    "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-                    "requires": {
-                        "ee-first": "1.1.1"
-                    }
                 },
                 "qs": {
                     "version": "6.11.0",
@@ -4396,119 +3689,6 @@
                     "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
                     "requires": {
                         "side-channel": "^1.0.4"
-                    }
-                },
-                "range-parser": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-                    "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-                },
-                "raw-body": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-                    "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-                    "requires": {
-                        "bytes": "3.1.2",
-                        "http-errors": "2.0.0",
-                        "iconv-lite": "0.4.24",
-                        "unpipe": "1.0.0"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                },
-                "send": {
-                    "version": "0.18.0",
-                    "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-                    "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-                    "requires": {
-                        "debug": "2.6.9",
-                        "depd": "2.0.0",
-                        "destroy": "1.2.0",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
-                        "fresh": "0.5.2",
-                        "http-errors": "2.0.0",
-                        "mime": "1.6.0",
-                        "ms": "2.1.3",
-                        "on-finished": "2.4.1",
-                        "range-parser": "~1.2.1",
-                        "statuses": "2.0.1"
-                    },
-                    "dependencies": {
-                        "ms": {
-                            "version": "2.1.3",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-                        }
-                    }
-                },
-                "serve-static": {
-                    "version": "1.15.0",
-                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-                    "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-                    "requires": {
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "parseurl": "~1.3.3",
-                        "send": "0.18.0"
-                    }
-                },
-                "statuses": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-                    "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-                },
-                "utils-merge": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-                    "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
-                },
-                "vary": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-                    "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-                }
-            }
-        },
-        "express-session": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
-            "integrity": "sha512-QdSbGRRg+JMvlYpancRDFXDmIMqjEdpowriwQc4Kz3mvPwTnOPD/h5FSS21+4z4Isosta+ULmEwL6F3/lylWWg==",
-            "requires": {
-                "cookie": "0.1.3",
-                "cookie-signature": "1.0.6",
-                "crc": "3.3.0",
-                "debug": "~2.2.0",
-                "depd": "~1.0.1",
-                "on-headers": "~1.0.0",
-                "parseurl": "~1.3.0",
-                "uid-safe": "~2.0.0",
-                "utils-merge": "1.0.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
-                    "requires": {
-                        "ms": "0.7.1"
-                    }
-                },
-                "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
-                },
-                "uid-safe": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
-                    "integrity": "sha512-PH/12q0a/sEGVS28fZ5evILW2Ayn13PwkYmCleDsIPm39vUIqN58hjyqtUd496kyMY6WkXtaDMDpS8nSCmNKTg==",
-                    "requires": {
-                        "base64-url": "1.2.1"
                     }
                 }
             }
@@ -4626,33 +3806,12 @@
                 "loader-utils": "^1.1.0",
                 "schema-utils": "^0.3.0",
                 "webpack-sources": "^1.0.1"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "2.6.4",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-                    "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-                    "requires": {
-                        "lodash": "^4.17.14"
-                    }
-                }
             }
         },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
-        },
-        "fancy-log": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
-            "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-            "requires": {
-                "ansi-gray": "^0.1.1",
-                "color-support": "^1.1.3",
-                "parse-node-version": "^1.0.0",
-                "time-stamp": "^1.0.0"
-            }
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -4762,12 +3921,6 @@
             "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
             "integrity": "sha512-0k45oWBokCqh2MOexeYKpyqmGKG+8mQ2Wd8iawx+uWd/weWJQAZ6SoPybagdCI4xFisag8iAR77WPm4h3pTfxA=="
         },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "optional": true
-        },
         "filename-regex": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -4782,40 +3935,33 @@
             }
         },
         "finalhandler": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
-            "integrity": "sha512-jJU2WE88OqUvwAIf/1K2G2fTdKKZ8LvSwYQyFFekDcmBnBmht38enbcmErnA7iNZktcEo/o2JAHYbe1QDOAgaA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
             "requires": {
-                "debug": "~2.2.0",
-                "escape-html": "1.0.2",
-                "on-finished": "~2.3.0",
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "statuses": "2.0.1",
                 "unpipe": "~1.0.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "requires": {
-                        "ms": "0.7.1"
+                        "ms": "2.0.0"
                     }
                 },
-                "escape-html": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-                    "integrity": "sha512-J5ahyCRC4liskWVAfkmosNWfG0eHQxI0W+Ko7k3cZaYVMfgt05dwZ68vw6S/TZM1BPvuTv3kq6CRCb7WWtBUVA=="
-                },
                 "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
                 }
             }
-        },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha512-uJ5vWrfBKMcE6y2Z8834dwEZj9mNGxYa3t3I53OwFeuZ8D9oc2E5zcsrkuhX6h4iYrjhiv0T3szQmxlAV9uxDg=="
         },
         "find-up": {
             "version": "1.1.2",
@@ -4893,11 +4039,6 @@
                         "universalify": "^0.1.0"
                     }
                 },
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                },
                 "is-number": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -4915,6 +4056,11 @@
                             }
                         }
                     }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
                 },
                 "micromatch": {
                     "version": "3.1.10",
@@ -4948,142 +4094,26 @@
             }
         },
         "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha512-vs+3unmJT45eczmcAZ6zMJtxN3l/QXeccaXQx5cu/MeJMhewVfoWZqibRkOxPnmoR59+Zy5hjabfQc6JLSah4g==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+            "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
             "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
+                "glob": "~5.0.0"
             },
             "dependencies": {
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
-                    }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
-        },
-        "fined": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
-            "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
-            "requires": {
-                "expand-tilde": "^2.0.2",
-                "is-plain-object": "^2.0.3",
-                "object.defaults": "^1.1.0",
-                "object.pick": "^1.2.0",
-                "parse-filepath": "^1.0.1"
-            }
-        },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha512-ArRi5axuv66gEsyl3UuK80CzW7t56hem73YGNYxNWTGNKFJUadSb9Gu9SHijYEUi8ulQMf1bJomYNwSCPHhtTQ=="
-        },
-        "flagged-respawn": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
         },
         "flat-cache": {
             "version": "2.0.1",
@@ -5093,37 +4123,6 @@
                 "flatted": "^2.0.0",
                 "rimraf": "2.6.3",
                 "write": "1.0.3"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.3",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
             }
         },
         "flatted": {
@@ -5191,9 +4190,9 @@
             }
         },
         "fresh": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-            "integrity": "sha512-akx5WBKAwMSg36qoHTuMMVncHWctlaDGslJASDYAhoLrzDUDCjZlOngNa/iC6lPm9aA0qk8pN5KnpmbJHSIIQQ=="
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
         },
         "fs-extra": {
             "version": "7.0.1",
@@ -5203,37 +4202,18 @@
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
                 "universalify": "^0.1.0"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                }
             }
         },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
         "fsevents": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-            "optional": true,
-            "requires": {
-                "bindings": "^1.5.0",
-                "nan": "^2.12.1"
-            },
-            "dependencies": {
-                "nan": {
-                    "version": "2.19.0",
-                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-                    "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
-                    "optional": true
-                }
-            }
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "optional": true
         },
         "fstream": {
             "version": "1.0.12",
@@ -5244,13 +4224,6 @@
                 "inherits": "~2.0.0",
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                }
             }
         },
         "function-bind": {
@@ -5315,11 +4288,11 @@
             }
         },
         "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha512-3IWbXGkDDHFX8zIlNdfnmhvlSMhpBO6tDr4InB8fGku6dh/gjFPGNqcdsXJajZg05x9jRzXbL6gCnCnuMap4tw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+            "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
             "requires": {
-                "globule": "~0.1.0"
+                "globule": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -5392,29 +4365,6 @@
                 "typescript": "2 - 4"
             },
             "dependencies": {
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
                 "parse5": {
                     "version": "6.0.1",
                     "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -5426,7 +4376,7 @@
         "gettext-parser": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
-            "integrity": "sha1-LFpmONiTk0ubVQN9CtgstwBLJnk=",
+            "integrity": "sha512-zL3eayB0jF+cr6vogH/VJKoKcj7uQj2TPByaaj6a4k/3elk9iq7fiwCM2FqdzS/umo021RetSanVisarzeb9Wg==",
             "requires": {
                 "encoding": "^0.1.11"
             }
@@ -5447,24 +4397,19 @@
                 "escape-string-regexp": "1.0.5",
                 "graceful-fs": "4.1.11",
                 "shelljs": "0.7.7"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "integrity": "sha512-9x6DLUuW+ROFdMTII9ec9t/FK8va6kYcC8/LggumssLM8kNv7IdFl3VrNUqgir2tJuBVxBga1QBoRziZacO5Zg=="
-                }
             }
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -5507,79 +4452,6 @@
                 "is-glob": "^4.0.1"
             }
         },
-        "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha512-owHtlMMXIAbxLjhUAO0HhW1/TB7kV0AwDduI3BLbYsWCaRzNIcLBu8N0wHZft2Za2SCmUXCEOdpZzC7k/H19eg==",
-            "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
-            }
-        },
-        "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha512-lzYWq1BJLBmtb9rzT6+lgbFlEW6Sc7B+Qs3RmsNA9lbdFSqLHhebfypPR3nbEOMeEQyawVXqSDH0aqjtImldow==",
-            "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha512-ZyqlgowMbfj2NPjxaZZ/EtsXlOch28FRXgMd64vqZWk1bT9+wvSRLYD1om9M7QfQru51zJPAT17qXm4/zd+9QA==",
-            "requires": {
-                "find-index": "^0.1.1"
-            }
-        },
-        "global-modules": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-            "requires": {
-                "global-prefix": "^1.0.1",
-                "is-windows": "^1.0.1",
-                "resolve-dir": "^1.0.0"
-            }
-        },
-        "global-prefix": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-            "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
-            "requires": {
-                "expand-tilde": "^2.0.2",
-                "homedir-polyfill": "^1.0.1",
-                "ini": "^1.3.4",
-                "is-windows": "^1.0.1",
-                "which": "^1.2.14"
-            }
-        },
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -5607,62 +4479,41 @@
             }
         },
         "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha512-3eIcA2OjPCm4VvwIwZPzIxCVssA8HSpM2C6c6kK5ufJH4FGwWoyqL3In19uuX4oe+TwH3w2P1nQDmW56iehO4A==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
+            "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
             "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
+                "glob": "~7.1.1",
+                "lodash": "^4.17.21",
+                "minimatch": "~3.0.2"
             },
             "dependencies": {
                 "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+                    "version": "7.1.7",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
                     "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ=="
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA=="
                 },
                 "lodash": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha512-0VSEDVec/Me2eATuoiQd8IjyBMMX0fahob8YJ96V1go2RjvCk1m1GxmtfXn8RNSaLaTtop7fsuhhu9oLk3hUgA=="
-                },
-                "lru-cache": {
-                    "version": "2.7.3",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                    "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
+                    "version": "4.17.21",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+                    "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
                 },
                 "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+                    "version": "3.0.8",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+                    "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
                     "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
+                        "brace-expansion": "^1.1.7"
                     }
                 }
-            }
-        },
-        "glogg": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
-            "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
-            "requires": {
-                "sparkles": "^1.0.0"
             }
         },
         "gopd": {
@@ -5674,12 +4525,9 @@
             }
         },
         "graceful-fs": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
-            "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
-            "requires": {
-                "natives": "^1.1.3"
-            }
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha512-9x6DLUuW+ROFdMTII9ec9t/FK8va6kYcC8/LggumssLM8kNv7IdFl3VrNUqgir2tJuBVxBga1QBoRziZacO5Zg=="
         },
         "graceful-readlink": {
             "version": "1.0.1",
@@ -5713,37 +4561,6 @@
                 "rimraf": "~2.2.8"
             },
             "dependencies": {
-                "dateformat": {
-                    "version": "1.0.12",
-                    "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                    "integrity": "sha512-5sFRfAAmbHdIts+eKjR9kYJoF0ViCMVX9yqLu5A7S/v+nd077KgCITOMiirmyCBiZpKLDXbBOkYm6tu7rX/TKg==",
-                    "requires": {
-                        "get-stdin": "^4.0.1",
-                        "meow": "^3.3.0"
-                    }
-                },
-                "findup-sync": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-                    "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
-                    "requires": {
-                        "glob": "~5.0.0"
-                    },
-                    "dependencies": {
-                        "glob": {
-                            "version": "5.0.15",
-                            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                            "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
-                            "requires": {
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "2 || 3",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
-                            }
-                        }
-                    }
-                },
                 "glob": {
                     "version": "7.0.6",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
@@ -5844,20 +4661,6 @@
             "requires": {
                 "chalk": "^1.1.1",
                 "file-sync-cmp": "^0.1.0"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                }
             }
         },
         "grunt-filerev": {
@@ -5868,20 +4671,6 @@
                 "chalk": "^1.0.0",
                 "convert-source-map": "^1.0.0",
                 "each-async": "^0.1.3"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                }
             }
         },
         "grunt-known-options": {
@@ -5898,13 +4687,6 @@
                 "grunt-legacy-log-utils": "~1.0.0",
                 "hooker": "~0.2.3",
                 "lodash": "~4.17.5"
-            },
-            "dependencies": {
-                "colors": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-                    "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w=="
-                }
             }
         },
         "grunt-legacy-log-utils": {
@@ -5916,18 +4698,6 @@
                 "lodash": "~4.3.0"
             },
             "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
                 "lodash": {
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
@@ -5980,18 +4750,6 @@
                 "path-exists": "^1.0.0"
             },
             "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -6024,239 +4782,6 @@
             "requires": {
                 "deep-for-each": "^1.0.5",
                 "lodash": "^4.7.0"
-            }
-        },
-        "gulp": {
-            "version": "3.8.11",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.8.11.tgz",
-            "integrity": "sha512-EG3Svvj9C8Q4rE9UXW9kDzNrMIf9hBEd5KC8Oayh1yG5uGWRxR1WgB31PAwL6WdT6rnittzoSaOvgtlTRm/jzQ==",
-            "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^0.5.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^0.3.2",
-                "liftoff": "^2.0.1",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^0.2.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha512-IrpJ+yoG4EOH8DFWuVg+8H1kW1Oaof0Wxe7cPcXW3x9BjkN/eVo54F15LyqemnDIUYskQWr9qvl/RihmSy6+xQ=="
-                }
-            }
-        },
-        "gulp-concat": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.2.0.tgz",
-            "integrity": "sha512-uUEzarPbEUoa051z85zHPZdBiDDUeWR1H/EIdS8ODPbdQpRayDnpK9RB1qsa6zMQXQThIWDw7BFNWq13239nOw==",
-            "requires": {
-                "gulp-util": "^2.2.5",
-                "through": "^2.3.4"
-            },
-            "dependencies": {
-                "dateformat": {
-                    "version": "1.0.12",
-                    "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                    "integrity": "sha512-5sFRfAAmbHdIts+eKjR9kYJoF0ViCMVX9yqLu5A7S/v+nd077KgCITOMiirmyCBiZpKLDXbBOkYm6tu7rX/TKg==",
-                    "requires": {
-                        "get-stdin": "^4.0.1",
-                        "meow": "^3.3.0"
-                    }
-                },
-                "gulp-util": {
-                    "version": "2.2.20",
-                    "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-                    "integrity": "sha512-9rtv4sj9EtCWYGD15HQQvWtRBtU9g1t0+w29tphetHxjxEAuBKQJkhGqvlLkHEtUjEgoqIpsVwPKU1yMZAa+wA==",
-                    "requires": {
-                        "chalk": "^0.5.0",
-                        "dateformat": "^1.0.7-1.2.3",
-                        "lodash._reinterpolate": "^2.4.1",
-                        "lodash.template": "^2.4.1",
-                        "minimist": "^0.2.0",
-                        "multipipe": "^0.1.0",
-                        "through2": "^0.5.0",
-                        "vinyl": "^0.2.1"
-                    }
-                },
-                "lodash._reinterpolate": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-                    "integrity": "sha512-QGEOOjJi7W9LIgDAMVgtGBb8Qgo8ieDlSOCoZjtG45ZNRvDJZjwVMTYlfTIWdNRUiR1I9BjIqQ3Zaf1+DYM94g=="
-                },
-                "lodash.escape": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                    "integrity": "sha512-PiEStyvZ8gz37qBE+HqME1Yc/ewb/59AMOu8pG7Ztani86foPTxgzckQvMdphmXPY6V5f20Ex/CaNBqHG4/ycQ==",
-                    "requires": {
-                        "lodash._escapehtmlchar": "~2.4.1",
-                        "lodash._reunescapedhtml": "~2.4.1",
-                        "lodash.keys": "~2.4.1"
-                    }
-                },
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
-                    "requires": {
-                        "lodash._isnative": "~2.4.1",
-                        "lodash._shimkeys": "~2.4.1",
-                        "lodash.isobject": "~2.4.1"
-                    }
-                },
-                "lodash.template": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-                    "integrity": "sha512-5yLOQwlS69xbaez3g9dA1i0GMAj8pLDHp8lhA4V7M1vRam1lqD76f0jg5EV+65frbqrXo1WH9ZfKalfYBzJ5yQ==",
-                    "requires": {
-                        "lodash._escapestringchar": "~2.4.1",
-                        "lodash._reinterpolate": "~2.4.1",
-                        "lodash.defaults": "~2.4.1",
-                        "lodash.escape": "~2.4.1",
-                        "lodash.keys": "~2.4.1",
-                        "lodash.templatesettings": "~2.4.1",
-                        "lodash.values": "~2.4.1"
-                    }
-                },
-                "lodash.templatesettings": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-                    "integrity": "sha512-vY3QQ7GxbeLe8XfTvoYDbaMHO5iyTDJS1KIZrxp00PRMmyBKr8yEcObHSl2ppYTwd8MgqPXAarTvLA14hx8ffw==",
-                    "requires": {
-                        "lodash._reinterpolate": "~2.4.1",
-                        "lodash.escape": "~2.4.1"
-                    }
-                },
-                "minimist": {
-                    "version": "0.2.4",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
-                    "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ=="
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "through2": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                    "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
-                    "requires": {
-                        "readable-stream": "~1.0.17",
-                        "xtend": "~3.0.0"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.2.3",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-                    "integrity": "sha512-4gFk9xrecazOTuFKcUYrE1TjHSYL63dio72D+q0d1mHF51FEcxTT2RHFpHbN5TNJgmPYHuVsBdhvXEOCDcytSA==",
-                    "requires": {
-                        "clone-stats": "~0.0.1"
-                    }
-                },
-                "xtend": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                    "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg=="
-                }
-            }
-        },
-        "gulp-uglify": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-0.3.2.tgz",
-            "integrity": "sha512-cHPg+SFkYt8cMOaQX+iNo+DUffzjIT+OtT3cDVS1umHPD6U6RQp6osx0DzuiRlENTTACNqINLAnWR6YWC4BXhw==",
-            "requires": {
-                "deepmerge": ">=0.2.7 <0.3.0-0",
-                "gulp-util": ">=3.0.0 <4.0.0-0",
-                "through2": ">=0.6.1 <1.0.0-0",
-                "uglify-js": "2.4.6"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                }
-            }
-        },
-        "gulp-util": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha512-q5oWPc12lwSFS9h/4VIjG+1NuNDlJ48ywV2JKItY4Ycc/n1fXJeYPVQsfu5ZrhQi7FGSDBalwUCLar/GyHXKGw==",
-            "requires": {
-                "array-differ": "^1.0.0",
-                "array-uniq": "^1.0.2",
-                "beeper": "^1.0.0",
-                "chalk": "^1.0.0",
-                "dateformat": "^2.0.0",
-                "fancy-log": "^1.1.0",
-                "gulplog": "^1.0.0",
-                "has-gulplog": "^0.1.0",
-                "lodash._reescape": "^3.0.0",
-                "lodash._reevaluate": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.template": "^3.0.0",
-                "minimist": "^1.1.0",
-                "multipipe": "^0.1.2",
-                "object-assign": "^3.0.0",
-                "replace-ext": "0.0.1",
-                "through2": "^2.0.0",
-                "vinyl": "^0.5.0"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "object-assign": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ=="
-                }
-            }
-        },
-        "gulplog": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha512-hm6N8nrm3Y08jXie48jsC55eCZz9mnb4OirAStEk2deqeyhXU3C1otDVh+ccttMuc1sBi6RX6ZJ720hs9RCvgw==",
-            "requires": {
-                "glogg": "^1.0.0"
             }
         },
         "handle-thing": {
@@ -6299,20 +4824,12 @@
         "has-color": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-            "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+            "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw=="
         },
         "has-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
             "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA=="
-        },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha512-+F4GzLjwHNNDEAJW2DC1xXfEoPkRDmUdJ7CBYw4MpqtDwOnqdImJl7GWlpqx+Wko6//J8uKTnIe4wZSv7yCqmw==",
-            "requires": {
-                "sparkles": "^1.0.0"
-            }
         },
         "has-property-descriptors": {
             "version": "1.0.2",
@@ -6400,31 +4917,6 @@
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.6.0",
                 "safe-buffer": "^5.2.0"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "3.6.2",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    }
-                }
             }
         },
         "hash.js": {
@@ -6485,14 +4977,6 @@
                 "react-is": "^16.7.0"
             }
         },
-        "homedir-polyfill": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-            "requires": {
-                "parse-passwd": "^1.0.0"
-            }
-        },
         "hooker": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
@@ -6532,6 +5016,11 @@
                         "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
                     }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 },
                 "string_decoder": {
                     "version": "1.1.1",
@@ -6641,32 +5130,11 @@
                 "ncname": "1.0.x",
                 "relateurl": "0.2.x",
                 "uglify-js": "2.6.x"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                    "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
-                    "requires": {
-                        "graceful-readlink": ">= 1.0.0"
-                    }
-                },
-                "uglify-js": {
-                    "version": "2.6.4",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
-                    "integrity": "sha512-5uPOZS1EDeuBIFwTYTlJefbQXWn+auebcRQpj5EtWr9E/7XwWVZ6YTgulZVSTHAEU9y/mYMYh2Mjt7TJ1iRNxQ==",
-                    "requires": {
-                        "async": "~0.2.6",
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
-                    }
-                }
             }
         },
         "htmldiff-js": {
-            "version": "github:dfoverdx/htmldiff-js#8cdfe9de9554536e0ac4238568af8db019066f75",
-            "from": "github:dfoverdx/htmldiff-js#master"
+            "version": "github:superdesk/htmldiff-js#8cdfe9de9554536e0ac4238568af8db019066f75",
+            "from": "github:superdesk/htmldiff-js#master"
         },
         "htmlparser2": {
             "version": "3.10.1",
@@ -6679,31 +5147,6 @@
                 "entities": "^1.1.1",
                 "inherits": "^2.0.1",
                 "readable-stream": "^3.1.1"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "3.6.2",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    }
-                }
             }
         },
         "http-deceiver": {
@@ -6712,12 +5155,15 @@
             "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw=="
         },
         "http-errors": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-            "integrity": "sha512-gMygNskMurDCWfoCdyh1gOeDfSbkAHXqz94QoPj5IHIUjC/BG8/xv7FSEUr7waR5RcAya4j58bft9Wu/wHNeXA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
             "requires": {
-                "inherits": "~2.0.1",
-                "statuses": "1"
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
             }
         },
         "http-parser-js": {
@@ -6726,34 +5172,19 @@
             "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
         },
         "http-proxy": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
-            "integrity": "sha512-lb5uBBW+eLzoZ/Tute8ENcbNvibErYYPzNhjZk9IZugBAl87kUSxzVLBwQ7FbU2qBuorbah6VObuXvp2DN1LbA==",
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
             "requires": {
-                "colors": "0.x.x",
-                "optimist": "0.6.x",
-                "pkginfo": "0.3.x",
-                "utile": "~0.2.1"
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
             },
             "dependencies": {
-                "colors": {
-                    "version": "0.6.2",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-                    "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw=="
-                },
-                "minimist": {
-                    "version": "0.0.10",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                    "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
-                },
-                "optimist": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                    "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-                    "requires": {
-                        "minimist": "~0.0.1",
-                        "wordwrap": "~0.0.2"
-                    }
+                "eventemitter3": {
+                    "version": "4.0.7",
+                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+                    "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
                 }
             }
         },
@@ -6791,11 +5222,6 @@
                         "repeat-element": "^1.1.2"
                     }
                 },
-                "eventemitter3": {
-                    "version": "4.0.7",
-                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-                    "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-                },
                 "expand-brackets": {
                     "version": "0.1.5",
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -6819,30 +5245,12 @@
                         }
                     }
                 },
-                "http-proxy": {
-                    "version": "1.18.1",
-                    "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-                    "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-                    "requires": {
-                        "eventemitter3": "^4.0.0",
-                        "follow-redirects": "^1.0.0",
-                        "requires-port": "^1.0.0"
-                    }
-                },
                 "is-glob": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
                     "requires": {
                         "is-extglob": "^2.1.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
                     }
                 },
                 "micromatch": {
@@ -6879,6 +5287,14 @@
                             }
                         }
                     }
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
                 }
             }
         },
@@ -6897,15 +5313,13 @@
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
         },
-        "i": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
-            "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q=="
-        },
         "iconv-lite": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-            "integrity": "sha512-8UmnaYeP5puk18SkBrYULVTiq7REcimhx+ykJVJBiaz89DQmVQAfS29ZhHah86la90/t0xy4vRk86/2cCwNodA=="
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            }
         },
         "icss-replace-symbols": {
             "version": "1.1.0",
@@ -7027,7 +5441,7 @@
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -7042,11 +5456,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "inquirer": {
             "version": "7.3.3",
@@ -7145,9 +5554,9 @@
             }
         },
         "interpret": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.10.tgz",
-            "integrity": "sha512-HB83/0g7v0RcRptkokRR6baiePOMbj0CJxAsDlbtybiLPwMq8jlBSmvQTp+RORblS7h9UgXIUd3LL6aU7DwqxQ=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
         },
         "invariant": {
             "version": "2.2.4",
@@ -7171,15 +5580,6 @@
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-        },
-        "is-absolute": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-            "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
-            }
         },
         "is-absolute-url": {
             "version": "2.1.0",
@@ -7226,11 +5626,12 @@
             }
         },
         "is-binary-path": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-            "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "optional": true,
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "^2.0.0"
             }
         },
         "is-boolean-object": {
@@ -7350,11 +5751,6 @@
                 "lower-case": "^1.1.0"
             }
         },
-        "is-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="
-        },
         "is-negative-zero": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -7426,19 +5822,6 @@
                 "has-tostringtag": "^1.0.0"
             }
         },
-        "is-relative": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-            "requires": {
-                "is-unc-path": "^1.0.0"
-            }
-        },
-        "is-set": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="
-        },
         "is-shared-array-buffer": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
@@ -7494,14 +5877,6 @@
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
         },
-        "is-unc-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-            "requires": {
-                "unc-path-regex": "^0.1.2"
-            }
-        },
         "is-upper-case": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
@@ -7515,26 +5890,12 @@
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
         },
-        "is-weakmap": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="
-        },
         "is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
             "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
             "requires": {
                 "call-bind": "^1.0.2"
-            }
-        },
-        "is-weakset": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-            "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
-            "requires": {
-                "call-bind": "^1.0.7",
-                "get-intrinsic": "^1.2.4"
             }
         },
         "is-windows": {
@@ -7548,9 +5909,9 @@
             "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw=="
         },
         "isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "isexe": {
             "version": "2.0.0",
@@ -7592,8 +5953,8 @@
             "integrity": "sha512-SvI6xngJ7UBrgujyxh+rj/0b+9iOxHi1X/1e4V7GjoWdGbPYjZmzGJD+wbA4auynUN8gKoJBJxHIHxE5JjmIdA=="
         },
         "jquery-ui": {
-            "version": "github:components/jqueryui#c34f8dbf3ba57b3784b93f26119f436c0e8288e1",
-            "from": "github:components/jqueryui#1.11.4"
+            "version": "github:superdesk/jqueryui#c34f8dbf3ba57b3784b93f26119f436c0e8288e1",
+            "from": "github:superdesk/jqueryui#1.11.4"
         },
         "js-base64": {
             "version": "2.6.4",
@@ -7627,7 +5988,7 @@
         "jsesc": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+            "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
             "dev": true
         },
         "json-loader": {
@@ -7641,21 +6002,6 @@
             "integrity": "sha512-mjd5eObNGOhWkKCztwVuF25KOzLj2T4TJaWXLBgCQPeoPRJrMxKNgjNBE8sPmXoWRT0WDlo4Itd/gTlFh29TFw==",
             "requires": {
                 "deep-equal": "^1.0.0"
-            },
-            "dependencies": {
-                "deep-equal": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-                    "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-                    "requires": {
-                        "is-arguments": "^1.1.1",
-                        "is-date-object": "^1.0.5",
-                        "is-regex": "^1.1.4",
-                        "object-is": "^1.1.5",
-                        "object-keys": "^1.1.1",
-                        "regexp.prototype.flags": "^1.5.1"
-                    }
-                }
             }
         },
         "json-schema": {
@@ -7694,14 +6040,6 @@
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "requires": {
                 "graceful-fs": "^4.1.6"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-                    "optional": true
-                }
             }
         },
         "jsprim": {
@@ -7724,84 +6062,6 @@
                 "object.assign": "^4.1.0"
             }
         },
-        "karma": {
-            "version": "0.12.37",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.37.tgz",
-            "integrity": "sha512-mlBxTuyYIRTO87ZOa+WOKFG+p37fAertzZwZcvix/60bzAcLobqcFwdj7qxsz9TXvNYmJVs4p0vJe9ePvG0HnA==",
-            "requires": {
-                "chokidar": "^1.0.1",
-                "colors": "^1.1.0",
-                "connect": "^2.29.2",
-                "di": "^0.0.1",
-                "glob": "^5.0.6",
-                "graceful-fs": "^3.0.6",
-                "http-proxy": "^0.10",
-                "lodash": "^3.8.0",
-                "log4js": "^0.6.25",
-                "mime": "^1.3.4",
-                "minimatch": "^2.0.7",
-                "optimist": "^0.6.1",
-                "q": "^1.4.1",
-                "rimraf": "^2.3.3",
-                "socket.io": "0.9.16",
-                "source-map": "^0.4.2",
-                "useragent": "^2.1.6"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
-                    "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "lodash": {
-                    "version": "3.10.1",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
-                },
-                "minimist": {
-                    "version": "0.0.10",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                    "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
-                },
-                "optimist": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                    "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-                    "requires": {
-                        "minimist": "~0.0.1",
-                        "wordwrap": "~0.0.2"
-                    }
-                },
-                "source-map": {
-                    "version": "0.4.4",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                    "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
-                    "requires": {
-                        "amdefine": ">=0.0.4"
-                    }
-                }
-            }
-        },
-        "karma-chrome-launcher": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.12.tgz",
-            "integrity": "sha512-Ws5wLWVZJyx44nDzA7NvQDn+k1RHQQCcH0txEoRu+yiQZ0tn2/aSvlrB9Zgcm34HkuW3Yn/Ocl+a1/wbcaH6vw==",
-            "requires": {
-                "which": "^1.0.9"
-            }
-        },
-        "karma-jasmine": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.1.6.tgz",
-            "integrity": "sha512-Z+aqAb/FKz7+ZLBSixWk9+ULeYT4kMd6LD8jT7vE4bgVD1xSSHK/4liBZnwsyAfKmctcllSNBbCRPVfyJ1KgTQ=="
-        },
         "keycloak-js": {
             "version": "10.0.2",
             "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-10.0.2.tgz",
@@ -7822,9 +6082,12 @@
             "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg=="
         },
         "kind-of": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+            "requires": {
+                "is-buffer": "^1.1.5"
+            }
         },
         "klaw-sync": {
             "version": "6.0.0",
@@ -7832,13 +6095,6 @@
             "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
             "requires": {
                 "graceful-fs": "^4.1.11"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                }
             }
         },
         "lazy-cache": {
@@ -7861,21 +6117,6 @@
             "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
-            }
-        },
-        "liftoff": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-            "integrity": "sha512-01zfGFqfORP1CGmZZP2Zn51zsqz4RltDi0RDOhbGoLYdUT5Lw+I2gX6QdwXhPITF6hPOHEOp+At6/L24hIg9WQ==",
-            "requires": {
-                "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
-                "fined": "^1.0.1",
-                "flagged-respawn": "^1.0.0",
-                "is-plain-object": "^2.0.4",
-                "object.map": "^1.0.0",
-                "rechoir": "^0.6.2",
-                "resolve": "^1.1.7"
             }
         },
         "load-grunt-config": {
@@ -7951,21 +6192,6 @@
                 "pify": "^2.0.0",
                 "pinkie-promise": "^2.0.0",
                 "strip-bom": "^2.0.0"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
-                    "requires": {
-                        "is-utf8": "^0.2.0"
-                    }
-                }
             }
         },
         "loader-runner": {
@@ -8014,108 +6240,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
             "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ=="
-        },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha512-mTzAr1aNAv/i7W43vOR/uD/aJ4ngbtsRaCubp2BfZhlGU/eORUjg/7F6X0orNMdv33JOrdgGybtvMN/po3EWrA=="
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha512-H94wl5P13uEqlCg7OcNNhMQ8KvWSIyqXzOPusRgHC9DK3o54P6P3xtbXlVbRABG4q5gSmp7EDdJ0MSuW9HX6Mg=="
-        },
-        "lodash._escapehtmlchar": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-            "integrity": "sha512-eHm2t2Lg476lq5v4FVmm3B5mCaRlDyTE8fnMfPCEq2o46G4au0qNXIKh7YWhjprm1zgSMLcMSs1XHMgkw02PbQ==",
-            "requires": {
-                "lodash._htmlescapes": "~2.4.1"
-            }
-        },
-        "lodash._escapestringchar": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-            "integrity": "sha512-iZ6Os4iipaE43pr9SBks+UpZgAjJgRC+lGf7onEoByMr1+Nagr1fmR7zCM6Q4RGMB/V3a57raEN0XZl7Uub3/g=="
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA=="
-        },
-        "lodash._htmlescapes": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-            "integrity": "sha512-g79hNmMOBVyV+4oKIHM7MWy9Awtk3yqf0Twlawr6f+CmG44nTwBh9I5XiLUnk39KTfYoDBpS66glQGgQCnFIuA=="
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ=="
-        },
-        "lodash._isnative": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-            "integrity": "sha512-BOlKGKNHhCHswGOWtmVb5zBygyxN7EmTuzVOSQI6QSoGhG+kvv71gICFS1TBpnqvT1n53txK8CDK3u5D2/GZxQ=="
-        },
-        "lodash._objecttypes": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-            "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q=="
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha512-Sjlavm5y+FUVIF3vF3B75GyXrzsfYV8Dlv3L4mEpuB9leg8N6yf/7rU06iLPx9fY0Mv3khVp9p7Dx0mGV6V5OQ=="
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha512-OrPwdDc65iJiBeUe5n/LIjd7Viy99bKwDdk7Z5ljfZg0uFRFlfQaCy9tZ4YMAag9WAZmlVpe1iZrkIMMSMHD3w=="
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA=="
-        },
-        "lodash._reunescapedhtml": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-            "integrity": "sha512-CfmZRU1Mk4E/5jh+Wu8lc7tuc3VkuwWZYVIgdPDH9NRSHgiL4Or3AA4JCIpgrkVzHOM+jKu2OMkAVquruhRHDQ==",
-            "requires": {
-                "lodash._htmlescapes": "~2.4.1",
-                "lodash.keys": "~2.4.1"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
-                    "requires": {
-                        "lodash._isnative": "~2.4.1",
-                        "lodash._shimkeys": "~2.4.1",
-                        "lodash.isobject": "~2.4.1"
-                    }
-                }
-            }
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ=="
-        },
-        "lodash._shimkeys": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-            "integrity": "sha512-lBrglYxLD/6KAJ8IEa5Lg+YHgNAL7FyKqXg4XOUI+Du/vtniLs1ZqS+yHNKPkK54waAgkdUnDOYaWf+rv4B+AA==",
-            "requires": {
-                "lodash._objecttypes": "~2.4.1"
-            }
-        },
         "lodash.assignin": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -8137,33 +6261,14 @@
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
         },
         "lodash.defaults": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-            "integrity": "sha512-5wTIPWwGGr07JFysAZB8+7JB2NjJKXDIwogSaRX5zED85zyUAQwtOqUk8AsJkkigUcL3akbHYXd5+BPtTGQPZw==",
-            "requires": {
-                "lodash._objecttypes": "~2.4.1",
-                "lodash.keys": "~2.4.1"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
-                    "requires": {
-                        "lodash._isnative": "~2.4.1",
-                        "lodash._shimkeys": "~2.4.1",
-                        "lodash.isobject": "~2.4.1"
-                    }
-                }
-            }
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
         },
         "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha512-n1PZMXgaaDWZDSvuNZ/8XOcYO2hOKDqZel5adtR30VKQAtoWs/5AOeFA0vPV8moiPzlqe7F4cP2tzpFewQyelQ==",
-            "requires": {
-                "lodash._root": "^3.0.0"
-            }
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+            "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
         },
         "lodash.filter": {
             "version": "4.6.0",
@@ -8185,38 +6290,10 @@
             "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
             "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ=="
         },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ=="
-        },
         "lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-        },
-        "lodash.isobject": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-            "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
-            "requires": {
-                "lodash._objecttypes": "~2.4.1"
-            }
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
-            "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
-            }
         },
         "lodash.map": {
             "version": "4.6.0",
@@ -8248,11 +6325,6 @@
             "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
             "integrity": "sha512-qkTuvgEzYdyhiJBx42YPzPo71R1aEr0z79kAv7Ixg8wPFEjgRgJdUsGMG3Hf3OYSF/kHI79XhNlt+5Ar6OzwxQ=="
         },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw=="
-        },
         "lodash.some": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
@@ -8263,82 +6335,10 @@
             "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
             "integrity": "sha512-+7y6zfkH4TqgS5DYKIqJuxmL5xT3WUUumVMZVRpDUo0UqJREwZqKmGo9wluj12FbPGl1UjRf2TnAImbw/bKtdw=="
         },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha512-0B4Y53I0OgHUJkt+7RmlDFWKjVAI/YUpWNiL9GQz5ORDr4ttgfQGo+phBWKFLJbBdtOwgMuUkdOHOnPg45jKmQ==",
-            "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash._basetostring": "^3.0.0",
-                "lodash._basevalues": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0",
-                "lodash.keys": "^3.0.0",
-                "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha512-TcrlEr31tDYnWkHFWDCV3dHYroKEXpJZ2YJYvJdhN+y4AkWMDZ5I4I8XDtUKqSAyG81N7w+I1mFEJtcED+tGqQ==",
-            "requires": {
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0"
-            }
-        },
         "lodash.uniq": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
-        },
-        "lodash.values": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-            "integrity": "sha512-fQwubKvj2Nox2gy6YnjFm8C1I6MIlzKUtBB+Pj7JGtloGqDDL5CPRr4DUUFWPwXWwAl2k3f4C3Aw8H1qAPB9ww==",
-            "requires": {
-                "lodash.keys": "~2.4.1"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
-                    "requires": {
-                        "lodash._isnative": "~2.4.1",
-                        "lodash._shimkeys": "~2.4.1",
-                        "lodash.isobject": "~2.4.1"
-                    }
-                }
-            }
-        },
-        "log4js": {
-            "version": "0.6.38",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
-            "integrity": "sha512-Cd+klbx7lkiaamEId9/0odHxv/PFHDz2E12kEfd6/CzIOZD084DzysASR/Dot4i1dYPBQKC3r2XIER+dfbLOmw==",
-            "requires": {
-                "readable-stream": "~1.0.2",
-                "semver": "~4.3.3"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha512-IrpJ+yoG4EOH8DFWuVg+8H1kW1Oaof0Wxe7cPcXW3x9BjkN/eVo54F15LyqemnDIUYskQWr9qvl/RihmSy6+xQ=="
-                }
-            }
         },
         "loglevel": {
             "version": "1.9.1",
@@ -8386,14 +6386,6 @@
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "requires": {
                 "yallist": "^4.0.0"
-            }
-        },
-        "make-iterator": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
-            "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-            "requires": {
-                "kind-of": "^6.0.2"
             }
         },
         "map-cache": {
@@ -8487,6 +6479,11 @@
                         "util-deprecate": "~1.0.1"
                     }
                 },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -8528,37 +6525,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
-        },
-        "method-override": {
-            "version": "2.3.10",
-            "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
-            "integrity": "sha512-Ks2/7e+3JuwQcpLybc6wTHyqg13HDjOhLcE+YaAEub9DbSxF+ieMvxUlybmWW9luRMh9Cd0rO9aNtzUT51xfNQ==",
-            "requires": {
-                "debug": "2.6.9",
-                "methods": "~1.1.2",
-                "parseurl": "~1.3.2",
-                "vary": "~1.1.2"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-                },
-                "vary": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-                    "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-                }
-            }
         },
         "methods": {
             "version": "1.1.2",
@@ -8624,11 +6590,11 @@
             "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
         },
         "minimatch": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-            "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "requires": {
-                "brace-expansion": "^1.0.0"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -8697,33 +6663,6 @@
             "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
             "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
         },
-        "morgan": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
-            "integrity": "sha512-WWxlTx5xCqbtSeX/gPVHUZBhAhSMfYQLgPrWHEN0FYnF+zf1Ju/Zct6rpeKmvzibrYF4QvFVws7IN61BxnKu+Q==",
-            "requires": {
-                "basic-auth": "~1.0.3",
-                "debug": "~2.2.0",
-                "depd": "~1.0.1",
-                "on-finished": "~2.3.0",
-                "on-headers": "~1.0.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
-                    "requires": {
-                        "ms": "0.7.1"
-                    }
-                },
-                "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
-                }
-            }
-        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8761,32 +6700,7 @@
                     "requires": {
                         "array-uniq": "^1.0.1"
                     }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
                 }
-            }
-        },
-        "multiparty": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
-            "integrity": "sha512-FX6dDOKzDpkrb5/+Imq+V6dmCZNnC02tMDiZfrgHSYgfQj6CVPGzOVqfbHKt/Vy4ZZsmMPXkulyLf92lCyvV7A==",
-            "requires": {
-                "readable-stream": "~1.1.9",
-                "stream-counter": "~0.2.0"
-            }
-        },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha512-7ZxrUybYv9NonoXgwoOqtStIu18D1c3eFZj27hqgf5kBrBF8Q+tE8V0MW8dKM5QLkQPh1JhhbKgHLY9kifov4Q==",
-            "requires": {
-                "duplexer2": "0.0.2"
             }
         },
         "mute-stream": {
@@ -8795,9 +6709,9 @@
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
         },
         "nan": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
-            "integrity": "sha512-Wm2/nFOm2y9HtJfgOLnctGbfvF23FcQZeyUZqDD8JQG3zO5kXh3MkQKiUaA68mJiVWrOzLFkAV1u6bC8P52DJA=="
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+            "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -8815,12 +6729,14 @@
                 "regex-not": "^1.0.0",
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+                }
             }
-        },
-        "natives": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -8834,11 +6750,6 @@
             "requires": {
                 "xml-char-classes": "^1.0.0"
             }
-        },
-        "ncp": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-            "integrity": "sha512-PfGU8jYWdRl4FqJfCy0IzbkGyFHntfWygZg46nFk/dJD/XRrk2cj0SsKSX9n5u5gE0E0YfEpKWrEkfjnlZSTXA=="
         },
         "nearley": {
             "version": "2.20.1",
@@ -8859,9 +6770,9 @@
             }
         },
         "negotiator": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-            "integrity": "sha512-oXmnazqehLNFohqgLxRyUdOQU9/UX0NpCpsnbjWUjM62ZM8oSOXYZpHc68XR130ftPNano0oQXGdREAplZRhaQ=="
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
         },
         "neo-async": {
             "version": "2.6.2",
@@ -8924,32 +6835,6 @@
                 "which": "1"
             },
             "dependencies": {
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
                 "semver": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -9021,20 +6906,10 @@
                         }
                     }
                 },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.2.1",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                        }
-                    }
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 }
             }
         },
@@ -9062,18 +6937,6 @@
                 "true-case-path": "^1.0.2"
             },
             "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
                 "cross-spawn": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -9081,67 +6944,6 @@
                     "requires": {
                         "lru-cache": "^4.0.1",
                         "which": "^1.2.9"
-                    }
-                },
-                "gaze": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-                    "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-                    "requires": {
-                        "globule": "^1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "minimatch": {
-                            "version": "3.1.2",
-                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                            "requires": {
-                                "brace-expansion": "^1.1.7"
-                            }
-                        }
-                    }
-                },
-                "globule": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
-                    "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
-                    "requires": {
-                        "glob": "~7.1.1",
-                        "lodash": "^4.17.21",
-                        "minimatch": "~3.0.2"
-                    },
-                    "dependencies": {
-                        "glob": {
-                            "version": "7.1.7",
-                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-                            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-                            "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
-                            }
-                        },
-                        "lodash": {
-                            "version": "4.17.21",
-                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-                            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-                        }
                     }
                 },
                 "lru-cache": {
@@ -9152,19 +6954,6 @@
                         "pseudomap": "^1.0.2",
                         "yallist": "^2.1.2"
                     }
-                },
-                "minimatch": {
-                    "version": "3.0.8",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-                    "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "nan": {
-                    "version": "2.19.0",
-                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-                    "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
                 },
                 "yallist": {
                     "version": "2.1.2",
@@ -9185,7 +6974,7 @@
         "nomnom": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-            "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+            "integrity": "sha512-5s0JxqhDx9/rksG2BTMVN1enjWSvPidpoSgViZU4ZXULyTe+7jxcCRLB6f42Z0l1xYJpleCBtSyY6Lwg3uu5CQ==",
             "requires": {
                 "chalk": "~0.4.0",
                 "underscore": "~1.6.0"
@@ -9194,12 +6983,12 @@
                 "ansi-styles": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-                    "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+                    "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA=="
                 },
                 "chalk": {
                     "version": "0.4.0",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                    "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+                    "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
                     "requires": {
                         "ansi-styles": "~1.0.0",
                         "has-color": "~0.1.0",
@@ -9209,7 +6998,7 @@
                 "strip-ansi": {
                     "version": "0.1.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-                    "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+                    "integrity": "sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg=="
                 }
             }
         },
@@ -9240,12 +7029,9 @@
             }
         },
         "normalize-path": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-            "requires": {
-                "remove-trailing-separator": "^1.0.1"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "normalize-range": {
             "version": "0.1.2",
@@ -9327,14 +7113,6 @@
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
                 }
             }
         },
@@ -9376,17 +7154,6 @@
                 "object-keys": "^1.1.1"
             }
         },
-        "object.defaults": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
-            "integrity": "sha512-c/K0mw/F11k4dEUBMW8naXUuBuhxRCfG7W+yFy8EcijU/rSmazOUd1XAEEe6bC0OuXY4HUKjTJv7xbxIMqdxrA==",
-            "requires": {
-                "array-each": "^1.0.1",
-                "array-slice": "^1.0.0",
-                "for-own": "^1.0.0",
-                "isobject": "^3.0.0"
-            }
-        },
         "object.entries": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
@@ -9406,15 +7173,6 @@
                 "define-properties": "^1.2.1",
                 "es-abstract": "^1.23.2",
                 "es-object-atoms": "^1.0.0"
-            }
-        },
-        "object.map": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
-            "integrity": "sha512-3+mAJu2PLfnSVGHwIWubpOFLscJANBKuB/6A4CxBstc4aqwQY0FWcsppuy4jU5GSB95yES5JHSI+33AWuS4k6w==",
-            "requires": {
-                "for-own": "^1.0.0",
-                "make-iterator": "^1.0.0"
             }
         },
         "object.omit": {
@@ -9460,9 +7218,9 @@
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
         },
         "on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "requires": {
                 "ee-first": "1.1.1"
             }
@@ -9473,9 +7231,9 @@
             "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
         },
         "once": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "requires": {
                 "wrappy": "1"
             }
@@ -9496,14 +7254,6 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "optimist": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-            "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-            "requires": {
-                "wordwrap": "~0.0.2"
-            }
-        },
         "optionator": {
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -9516,26 +7266,6 @@
                 "type-check": "~0.3.2",
                 "word-wrap": "~1.2.3"
             }
-        },
-        "options": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-            "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg=="
-        },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha512-DrQ43ngaJ0e36j2CHyoDoIg1K4zbc78GnTQESebK9vu6hj4W5/pvfSFO/kgM620Yd0YnhseSNYsLK3/SszZ5NQ==",
-            "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
-            }
-        },
-        "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha512-PMX5ehiNri4+lgk9fl09xuPeciGmyPyVUSBwwPT4C/3EHGxoVf7UdgKDE3SLBD4pUDmlzrg1L1cK5igrp+Tyuw=="
         },
         "original": {
             "version": "1.0.2",
@@ -9658,22 +7388,7 @@
                         "inherits": "^2.0.1",
                         "safe-buffer": "^5.0.1"
                     }
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 }
-            }
-        },
-        "parse-filepath": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
-            "integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
-            "requires": {
-                "is-absolute": "^1.0.0",
-                "map-cache": "^0.2.0",
-                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -9709,16 +7424,6 @@
             "requires": {
                 "error-ex": "^1.2.0"
             }
-        },
-        "parse-node-version": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
-        },
-        "parse-passwd": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-            "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="
         },
         "parse5": {
             "version": "7.1.2",
@@ -9869,7 +7574,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -9886,19 +7591,6 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
-        "path-root": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-            "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
-            "requires": {
-                "path-root-regex": "^0.1.0"
-            }
-        },
-        "path-root-regex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-            "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ=="
-        },
         "path-to-regexp": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -9908,11 +7600,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-        },
-        "pause": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
-            "integrity": "sha512-aeHLgQCtI3tcuYVnrvAeVb4Tkm1za4r3YDv3hMeUxcRxet3dbEhJOdtoMrsT/Q5tY3Oy2A1A9FD5el5tWp2FSg=="
         },
         "pbkdf2": {
             "version": "3.1.2",
@@ -9985,15 +7672,10 @@
                 "find-up": "^1.0.0"
             }
         },
-        "pkginfo": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-            "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A=="
-        },
         "po2json": {
             "version": "0.4.5",
             "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.4.5.tgz",
-            "integrity": "sha1-R7spUtoy1Yob4vJWpZjuvAt0URg=",
+            "integrity": "sha512-JH0hgi1fC0t9UvdiyS7kcVly0N1WNey4R2YZ/jPaxQKYm6Cfej7ZTgiEy8LP2JwoEhONceiNS8JH5mWPQkiXeA==",
             "requires": {
                 "gettext-parser": "1.1.0",
                 "nomnom": "1.8.1"
@@ -10003,11 +7685,6 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pofile/-/pofile-1.0.11.tgz",
             "integrity": "sha512-Vy9eH1dRD9wHjYt/QqXcTz+RnX/zg53xK+KljFSX30PvdDMb2z+c6uDUeblUGqqJgz3QFsdlA0IJvHziPmWtQg=="
-        },
-        "policyfile": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
-            "integrity": "sha512-UfDtlscNialXfmVEwEPm0t/5qtM0xPK025eYWd/ilv89hxLIhVQmt3QIzMHincLO2MBtZyww0386pt13J4aIhQ=="
         },
         "popper-max-size-modifier": {
             "version": "0.2.0",
@@ -10029,14 +7706,6 @@
                 "mkdirp": "^0.5.6"
             },
             "dependencies": {
-                "async": {
-                    "version": "2.6.4",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-                    "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-                    "requires": {
-                        "lodash": "^4.17.14"
-                    }
-                },
                 "debug": {
                     "version": "3.2.7",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -10068,25 +7737,6 @@
                 "supports-color": "^3.2.3"
             },
             "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
-                        }
-                    }
-                },
                 "supports-color": {
                     "version": "3.2.3",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -10607,11 +8257,6 @@
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
             "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ=="
         },
-        "pretty-hrtime": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-0.2.2.tgz",
-            "integrity": "sha512-3Vo9WpVf+ROOm91HwrtEUvfC/RY6Onwnz+oiNEzAZP0xOpUZb8ZOKMw1+bKS57Q/1DGAeNan5pbeCpaUkPuprA=="
-        },
         "primeicons": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-2.0.0.tgz",
@@ -10739,9 +8384,9 @@
             "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
         },
         "qs": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-            "integrity": "sha512-8MPmJ83uBOPsQj5tQCv4g04/nTiY+d17yl9o3Bw73vC6XlEm2POIRRlOgWJ8i74bkGLII670cDJJZkgiZ2sIkg=="
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
         },
         "query-string": {
             "version": "4.3.4",
@@ -10794,11 +8439,6 @@
                 "ret": "~0.1.10"
             }
         },
-        "random-bytes": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-            "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ=="
-        },
         "randomatic": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -10813,6 +8453,11 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
                     "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
                 }
             }
         },
@@ -10834,9 +8479,9 @@
             }
         },
         "range-parser": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-            "integrity": "sha512-nDsRrtIxVUO5opg/A8T2S3ebULVIfuh8ECbh4w3N4mWxIiT3QILDJDUQayPqm2e8Q8NUa0RSUkGCfe33AfjR3Q=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
         },
         "rangy": {
             "version": "1.3.0",
@@ -10849,24 +8494,28 @@
             "integrity": "sha512-pIzHpAggyTOGJE3ruAKdZNK5qhO4V21kR7lwpdUM875yHpq1cqeGzvs78/RufF3g7NaAvVmMPCbaV9uUhQzJ3A=="
         },
         "raw-body": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-            "integrity": "sha512-x4d27vsIG04gZ1imkuDXB9Rd/EkAx5kYzeMijIYw1PAor0Ld3nTlkQQwDjKu42GdRUFCX1AfGnTSQB4O57eWVg==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "requires": {
-                "bytes": "2.4.0",
-                "iconv-lite": "0.4.13",
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             },
             "dependencies": {
                 "bytes": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-                    "integrity": "sha512-SvUX8+c/Ga454a4fprIdIUzUN9xfd1YTvYh7ub5ZPJ+ZJ/+K2Bp6IpWGmnw8r3caLTsmhvJAKZz3qjIo9+XuCQ=="
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
                 },
                 "iconv-lite": {
-                    "version": "0.4.13",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-                    "integrity": "sha512-QwVuTNQv7tXC5mMWFX5N5wGjmybjNBBD8P3BReTkPmipoxTUFgWM2gXNvldHQr6T14DH0Dh6qBVg98iJt7u4mQ=="
+                    "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
                 }
             }
         },
@@ -10975,11 +8624,6 @@
                 "prop-types": "^15.6.0"
             }
         },
-        "react-fast-compare": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-            "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
-        },
         "react-geolookup": {
             "version": "github:superdesk/react-geolookup#e6ce40bc3e2d2dc7df2776e95fd75bb99ac56218",
             "from": "github:superdesk/react-geolookup",
@@ -10999,9 +8643,9 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "react-lazyload": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.2.0.tgz",
-            "integrity": "sha512-zJlrG8QyVZz4+xkYZH5v1w3YaP5wEFaYSUWC4CT9UXfK75IfRAIEdnyIUF+dXr3kX2MOtL1lUaZmaQZqrETwgw=="
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.2.1.tgz",
+            "integrity": "sha512-oDLlLOI/rRLY0fUh/HYFCy4CqCe7zdJXv6oTl2pC30tN3ezWxvwcdHYfD/ZkrGOMOOT5pO7hNLSvg7WsmAij1w=="
         },
         "react-lifecycles-compat": {
             "version": "3.0.4",
@@ -11046,25 +8690,6 @@
             "integrity": "sha512-lT/ne7hZzctGDli4QzUAou0JjfZgxKmtl9/r30B5UVonICZIy1u0SrAkdlEZ5ubgzrOykBeCmxkTWi5IyPg4AQ==",
             "requires": {
                 "prop-types": "^15.6.1"
-            }
-        },
-        "react-popper": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-            "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-            "requires": {
-                "react-fast-compare": "^3.0.1",
-                "warning": "^4.0.2"
-            },
-            "dependencies": {
-                "warning": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-                    "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-                    "requires": {
-                        "loose-envify": "^1.0.0"
-                    }
-                }
             }
         },
         "react-portal": {
@@ -11208,11 +8833,6 @@
                 "path-type": "^1.0.0"
             },
             "dependencies": {
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                },
                 "path-type": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -11235,153 +8855,22 @@
             }
         },
         "readable-stream": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-            "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
             }
         },
         "readdirp": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-            "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "optional": true,
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "micromatch": "^3.1.10",
-                "readable-stream": "^2.0.2"
-            },
-            "dependencies": {
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.8",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
-                }
+                "picomatch": "^2.2.1"
             }
         },
         "recast": {
@@ -11419,12 +8908,6 @@
                 "strip-indent": "^1.0.1"
             }
         },
-        "redis": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
-            "integrity": "sha512-0Pgb0jOLfn6eREtEIRn/ifyZJjl2H+wUY4F/Pe7T4UhmoSrZ/1HU5ZqiBpDk8I8Wbyv2N5DpXKzbEtMj3drprg==",
-            "optional": true
-        },
         "reduce-css-calc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
@@ -11433,13 +8916,6 @@
                 "balanced-match": "^0.4.2",
                 "math-expression-evaluator": "^1.2.14",
                 "reduce-function-call": "^1.0.1"
-            },
-            "dependencies": {
-                "balanced-match": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                    "integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg=="
-                }
             }
         },
         "reduce-function-call": {
@@ -11448,6 +8924,13 @@
             "integrity": "sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==",
             "requires": {
                 "balanced-match": "^1.0.0"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+                    "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+                }
             }
         },
         "redux": {
@@ -11524,7 +9007,7 @@
         "regexpu-core": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-            "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+            "integrity": "sha512-Ci+lDRlvAElKjFp5keqmVUaJLqZiHywekXhshT6wVUyDObGPdymNPhxBmf38ZVsaUGOnZ3Fot9YzxvoI31ymYw==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.2.1",
@@ -11535,13 +9018,13 @@
         "regjsgen": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+            "integrity": "sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g==",
             "dev": true
         },
         "regjsparser": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+            "integrity": "sha512-jlQ9gYLfk2p3V5Ag5fYhA7fv7OHzd1KUH0PRP46xc3TgwjwgROIW572AfYg/X9kaNq/LJnu6oJcFRXlIrGoTRw==",
             "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
@@ -11575,11 +9058,6 @@
                 "is-finite": "^1.0.0"
             }
         },
-        "replace-ext": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-            "integrity": "sha512-AFBWBy9EVRTa/LhEcG8QDP3FvpwZqmvN2QFDuJswFeaVhWnZMp8q3E6Zd90SR04PlIwfGdyVjNyLPyen/ek5CQ=="
-        },
         "request": {
             "version": "2.88.2",
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -11607,11 +9085,6 @@
                 "uuid": "^3.3.2"
             },
             "dependencies": {
-                "qs": {
-                    "version": "6.5.3",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-                    "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
-                },
                 "uuid": {
                     "version": "3.4.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -11672,15 +9145,6 @@
                 }
             }
         },
-        "resolve-dir": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-            "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
-            "requires": {
-                "expand-tilde": "^2.0.0",
-                "global-modules": "^1.0.0"
-            }
-        },
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -11704,23 +9168,7 @@
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-        },
-        "response-time": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
-            "integrity": "sha512-MUIDaDQf+CVqflfTdQ5yam+aYCkXj1PY8fjlPDQ6ppxJlmgZb864pHtA750mayywNg8tx4rS7qH9JXd/OF+3gw==",
-            "requires": {
-                "depd": "~1.1.0",
-                "on-headers": "~1.0.1"
-            },
-            "dependencies": {
-                "depd": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-                    "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
-                }
-            }
+            "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg=="
         },
         "restore-cursor": {
             "version": "3.1.0",
@@ -11750,34 +9198,11 @@
             }
         },
         "rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "requires": {
                 "glob": "^7.1.3"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                }
             }
         },
         "ripemd160": {
@@ -11788,11 +9213,6 @@
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
             }
-        },
-        "rndm": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
-            "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw=="
         },
         "rrule": {
             "version": "2.2.9",
@@ -11838,19 +9258,12 @@
                 "get-intrinsic": "^1.2.4",
                 "has-symbols": "^1.0.3",
                 "isarray": "^2.0.5"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-                }
             }
         },
         "safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "safe-regex": {
             "version": "1.1.0",
@@ -11917,33 +9330,12 @@
                         "wrap-ansi": "^2.0.0"
                     }
                 },
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
                     "requires": {
                         "number-is-nan": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "string-width": {
@@ -11990,14 +9382,6 @@
                 "pify": "^3.0.0"
             },
             "dependencies": {
-                "async": {
-                    "version": "2.6.4",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-                    "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-                    "requires": {
-                        "lodash": "^4.17.14"
-                    }
-                },
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -12091,51 +9475,44 @@
             }
         },
         "send": {
-            "version": "0.13.2",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
-            "integrity": "sha512-cQ0rmXHrdO2Iof08igV2bG/yXWD106ANwBg6DkGQNT2Vsznbgq6T0oAIQboy1GoFsIuy51jCim26aA9tj3Z3Zg==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
             "requires": {
-                "debug": "~2.2.0",
-                "depd": "~1.1.0",
-                "destroy": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
-                "etag": "~1.7.0",
-                "fresh": "0.3.0",
-                "http-errors": "~1.3.1",
-                "mime": "1.3.4",
-                "ms": "0.7.1",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.0.3",
-                "statuses": "~1.2.1"
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "requires": {
-                        "ms": "0.7.1"
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                        }
                     }
                 },
-                "depd": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-                    "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
-                },
-                "mime": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-                    "integrity": "sha512-sAaYXszED5ALBt665F0wMQCUXpGuZsGdopoqcHPdL39ZYdi7uHoZlhrfZfhv8WzivhBzr/oXwaj+yiK5wY8MXQ=="
-                },
                 "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
-                },
-                "statuses": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-                    "integrity": "sha512-pVEuxHdSGrt8QmQ3LOZXLhSA6MP/iPqKzZeO6Squ7PNGkA/9MBsSfV0/L+bIxkoDmjF4tZcLpcVq/fkqoHvuKg=="
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
                 }
             }
         },
@@ -12148,66 +9525,75 @@
                 "upper-case-first": "^1.1.2"
             }
         },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha512-YL8BPm0tp6SlXef/VqYpA/ijmTsDP2ZEXzsnqjkaWS7NP7Bfvw18NboL0O8WCIjy67sOCG3MYSK1PB4GC9XdtQ=="
-        },
-        "serve-favicon": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
-            "integrity": "sha512-oHEaA3ohvKxEWhjP97cQ6QuTTbMBF3AxDyMSvBtvnl1jXaB2Ik6kXE7nUtPM3YVU5VHCDe6n7JZrFCWzQuvXEQ==",
-            "requires": {
-                "etag": "~1.7.0",
-                "fresh": "0.3.0",
-                "ms": "0.7.2",
-                "parseurl": "~1.3.1"
-            },
-            "dependencies": {
-                "ms": {
-                    "version": "0.7.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                    "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA=="
-                }
-            }
-        },
         "serve-index": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
-            "integrity": "sha512-g18EQWY83uFBldFpCyK/a49yxQgIMEMLA6U9f66FiI848mLkMO8EY/xRAZAoCwNFwSUAiArCF3mdjaNXpd3ghw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
             "requires": {
-                "accepts": "~1.2.13",
-                "batch": "0.5.3",
-                "debug": "~2.2.0",
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
                 "escape-html": "~1.0.3",
-                "http-errors": "~1.3.1",
-                "mime-types": "~2.1.9",
-                "parseurl": "~1.3.1"
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "requires": {
-                        "ms": "0.7.1"
+                        "ms": "2.0.0"
                     }
                 },
+                "depd": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+                    "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+                },
+                "http-errors": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+                    "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.0",
+                        "statuses": ">= 1.4.0 < 2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+                },
                 "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+                },
+                "statuses": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                    "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
                 }
             }
         },
         "serve-static": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
-            "integrity": "sha512-ScsFovjz3Db+vGgpofR/U8p8UULEcGV9akqyo8TQ1mMnjcxemE7Y5Muo+dvy3tJLY/doY2v1H61eCBMYGmwfrA==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
             "requires": {
+                "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
-                "parseurl": "~1.3.1",
-                "send": "0.13.2"
+                "parseurl": "~1.3.3",
+                "send": "0.18.0"
             }
         },
         "set-blocking": {
@@ -12326,34 +9712,6 @@
                 "glob": "^7.0.0",
                 "interpret": "^1.0.0",
                 "rechoir": "^0.6.2"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "interpret": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                }
             }
         },
         "shortid": {
@@ -12371,11 +9729,6 @@
                 "get-intrinsic": "^1.2.4",
                 "object-inspect": "^1.13.1"
             }
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
         },
         "signal-exit": {
             "version": "3.0.7",
@@ -12501,45 +9854,6 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "requires": {
                 "kind-of": "^3.2.0"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
-        "socket.io": {
-            "version": "0.9.16",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
-            "integrity": "sha512-9ivO8P4B3ZGZM3/vFwIMriDelss7SutBrPYZe3AWKO0ut4TeFScHevqE54BXfxVtzrRgIy38bY/hgE6UHQ/Jkg==",
-            "requires": {
-                "base64id": "0.1.0",
-                "policyfile": "0.0.4",
-                "redis": "0.7.3",
-                "socket.io-client": "0.9.16"
-            }
-        },
-        "socket.io-client": {
-            "version": "0.9.16",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
-            "integrity": "sha512-wSM7PKJkzpGqUAo6d6SAn+ph4xeQJ6nzyDULRJAX1G7e6Xm0wNuMh2RpNvwXrHMzoV9Or5hti7LINiQAm1H2yA==",
-            "requires": {
-                "active-x-obfuscator": "0.0.1",
-                "uglify-js": "1.2.5",
-                "ws": "0.4.x",
-                "xmlhttprequest": "1.4.2"
-            },
-            "dependencies": {
-                "uglify-js": {
-                    "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
-                    "integrity": "sha512-Ps1oQryKOcRDYuAN1tGpPWd/DIRMcdLz4p7JMxLjJiFvp+aaG01IEu0ZSoVvYUSxIkvW7k2X50BCW2InguEGlg=="
-                }
             }
         },
         "sockjs": {
@@ -12628,11 +9942,6 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
-        },
-        "sparkles": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
         },
         "spdx-correct": {
             "version": "3.2.0",
@@ -12734,6 +10043,13 @@
                         "safe-buffer": "~5.1.1",
                         "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
+                    },
+                    "dependencies": {
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                        }
                     }
                 },
                 "string_decoder": {
@@ -12742,6 +10058,13 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "requires": {
                         "safe-buffer": "~5.1.0"
+                    },
+                    "dependencies": {
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                        }
                     }
                 }
             }
@@ -12795,9 +10118,9 @@
             }
         },
         "statuses": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         },
         "stdout-stream": {
             "version": "1.4.1",
@@ -12826,6 +10149,11 @@
                         "util-deprecate": "~1.0.1"
                     }
                 },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -12834,14 +10162,6 @@
                         "safe-buffer": "~5.1.0"
                     }
                 }
-            }
-        },
-        "stop-iteration-iterator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-            "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-            "requires": {
-                "internal-slot": "^1.0.4"
             }
         },
         "stream-browserify": {
@@ -12872,6 +10192,11 @@
                         "util-deprecate": "~1.0.1"
                     }
                 },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -12880,19 +10205,6 @@
                         "safe-buffer": "~5.1.0"
                     }
                 }
-            }
-        },
-        "stream-consume": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-            "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
-        },
-        "stream-counter": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
-            "integrity": "sha512-GjA2zKc2iXUUKRcOxXQmhEx0Ev3XHJ6c8yWGqhQjWwhGrqNwSsvq9YlRLgoGtZ5Kx2Ln94IedaqJ5GUG6aBbxA==",
-            "requires": {
-                "readable-stream": "~1.1.8"
             }
         },
         "stream-http": {
@@ -12925,6 +10237,11 @@
                         "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
                     }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 },
                 "string_decoder": {
                     "version": "1.1.1",
@@ -12998,9 +10315,12 @@
             }
         },
         "string_decoder": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -13011,11 +10331,10 @@
             }
         },
         "strip-bom": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-            "integrity": "sha512-qVAeAIjblKDp/8Cd0tJdxpe3Iq/HooI7En98alEaMbz4Wedlrcj3WI72dDQSrziRW5IQ0zeBo3JXsmS8RcS9jg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
             "requires": {
-                "first-chunk-stream": "^1.0.0",
                 "is-utf8": "^0.2.0"
             }
         },
@@ -13079,7 +10398,7 @@
             }
         },
         "superdesk-core": {
-            "version": "github:superdesk/superdesk-client-core#d78a0270f70fb57b33a121d462f1b6acd0994b25",
+            "version": "github:superdesk/superdesk-client-core#b3516226586fa6893aca84619583f1c9e2f33b53",
             "from": "github:superdesk/superdesk-client-core#release/2.7",
             "requires": {
                 "@metadata/exif": "github:superdesk/exif#431066d",
@@ -13098,8 +10417,8 @@
                 "angular-contenteditable": "0.3.9",
                 "angular-dynamic-locale": "0.1.32",
                 "angular-embed": "github:superdesk/angular-embed#d75968e",
-                "angular-embedly": "github:Urigo/angular-embedly#0.0.8",
-                "angular-gettext": "github:tomaskikutis/angular-gettext#master",
+                "angular-embedly": "github:superdesk/angular-embedly#master",
+                "angular-gettext": "github:superdesk/angular-gettext#master",
                 "angular-i18n": "1.6.9",
                 "angular-mocks": "1.6.9",
                 "angular-moment": "1.2.0",
@@ -13109,10 +10428,11 @@
                 "bootstrap": "3.3.7",
                 "classnames": "2.2.5",
                 "css-loader": "0.28.10",
+                "csstype": "2.6.17",
                 "d3": "3.5.17",
                 "date-fns": "^2.16.0",
                 "diff-match-patch": "1.0.0",
-                "docs-soap": "github:superdesk/docs-soap#master",
+                "docs-soap": "github:superdesk/docs-soap#v1",
                 "draft-js": "github:superdesk/draft-js#master",
                 "draft-js-export-html": "1.3.3",
                 "eslint": "6.6.0",
@@ -13132,11 +10452,11 @@
                 "grunt-webpack": "3.0.2",
                 "hls.js": "0.12.4",
                 "html-loader": "0.5.5",
-                "htmldiff-js": "github:dfoverdx/htmldiff-js#master",
+                "htmldiff-js": "github:superdesk/htmldiff-js#master",
                 "immutable": "3.8.2",
                 "jquery": "3.3.1",
                 "jquery-jcrop": "0.9.13",
-                "jquery-ui": "github:components/jqueryui#1.11.4",
+                "jquery-ui": "github:superdesk/jqueryui#1.11.4",
                 "json-loader": "~0.5.4",
                 "json-merge-patch": "0.2.3",
                 "json5": "0.5.1",
@@ -13175,7 +10495,7 @@
                 "sass-loader": "6.0.6",
                 "shortid": "2.2.8",
                 "style-loader": "0.20.2",
-                "superdesk-ui-framework": "^3.0.71",
+                "superdesk-ui-framework": "^3.0.82",
                 "ts-loader": "3.5.0",
                 "typescript": "4.9.5",
                 "uuid": "8.3.1",
@@ -13185,7 +10505,7 @@
             }
         },
         "superdesk-planning": {
-            "version": "github:superdesk/superdesk-planning#4bdf2214bd9ac9bcd2c5389239350363b58ba907",
+            "version": "github:superdesk/superdesk-planning#dd5b524d196a6a84b20477721b43fcab6ef2a0eb",
             "from": "github:superdesk/superdesk-planning#release/2.7",
             "requires": {
                 "dompurify": "^1.0.11",
@@ -13238,11 +10558,10 @@
             }
         },
         "superdesk-ui-framework": {
-            "version": "3.0.75",
-            "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-3.0.75.tgz",
-            "integrity": "sha512-kXoBOAMRPrR7CMfK/MdR+fYeK2b+lQrJpTXT0N5eVsrwhSK6nUYkJlPQaHnfmLDD6JqhFev0RnmWABD3OGz7sw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-3.1.1.tgz",
+            "integrity": "sha512-njd4HLSodGZPWFGvZbFQsC66DcjhCxfYFqzoWZPfqx/aQznpon/0NeAMQ8ubqhUpj1gKPlULoVR4+NQtEwvvYQ==",
             "requires": {
-                "@material-ui/lab": "^4.0.0-alpha.56",
                 "@popperjs/core": "^2.4.0",
                 "@superdesk/primereact": "^5.0.2-12",
                 "@superdesk/react-resizable-panels": "0.0.39",
@@ -13258,15 +10577,9 @@
                 "primeicons": "2.0.0",
                 "react-beautiful-dnd": "^13.0.0",
                 "react-id-generator": "^3.0.0",
-                "react-popper": "^2.2.3",
                 "react-scrollspy": "^3.4.3"
             },
             "dependencies": {
-                "@types/node": {
-                    "version": "14.18.63",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-                    "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
-                },
                 "date-fns": {
                     "version": "2.7.0",
                     "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.7.0.tgz",
@@ -13296,13 +10609,6 @@
                 "mkdirp": "~0.5.1",
                 "sax": "~1.2.1",
                 "whet.extend": "~0.9.9"
-            },
-            "dependencies": {
-                "colors": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-                    "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w=="
-                }
             }
         },
         "swap-case": {
@@ -13390,61 +10696,15 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
         },
-        "through2": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-            "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-                },
-                "readable-stream": {
-                    "version": "2.3.8",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
-        },
         "thunky": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha512-Y9q1GaV/BO65Z9Yf4NOGMuwt3SGdptkZBnaaKfTQakrDyCLiuO1Kc5wxW4xLdsjzunRtqtOdhekiUFmZbklwYQ==",
-            "requires": {
-                "os-homedir": "^1.0.0"
-            }
-        },
         "time-stamp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha512-gLCeArryy2yNTRzTGKbZbloctj64jkZ57hj5zdraXue6aFgd6PmvVtEyiUU+hvU0v7q08oVv8r8ev0tRo6bvgw=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.2.0.tgz",
+            "integrity": "sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA=="
         },
         "timers-browserify": {
             "version": "2.0.12",
@@ -13458,11 +10718,6 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
             "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
-        },
-        "tinycolor": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
-            "integrity": "sha512-+CorETse1kl98xg0WAzii8DTT4ABF4R3nquhrkIbVGcw1T8JYs5Gfx9xEfGINPUZGDj9C4BmOtuKeaTtuuRolg=="
         },
         "title-case": {
             "version": "2.1.1",
@@ -13492,16 +10747,6 @@
             "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
             "requires": {
                 "kind-of": "^3.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
             }
         },
         "to-regex": {
@@ -13548,29 +10793,6 @@
             "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
             "requires": {
                 "glob": "^7.1.2"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                }
             }
         },
         "ts-loader": {
@@ -13674,6 +10896,11 @@
                         }
                     }
                 },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -13722,11 +10949,6 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "tsscmp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-            "integrity": "sha512-aP/vy9xYiYGvtpW4xBkxdoeqbT+nNeo/37cdQk3iSiGz0xKb20XwOgBSqYo1DzEqt1ycPubEfPU3oHgzsRRL3g=="
         },
         "tsutils": {
             "version": "3.21.0",
@@ -13848,23 +11070,20 @@
             "integrity": "sha512-xV8kqRKM+jhMvcHWUKthV9fNebIzrNy//2O9ZwWcfiBFR5f25XVZPLlEajk/sf3Ra15V92isyQqnIEXRDaZWEA=="
         },
         "uglify-js": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.6.tgz",
-            "integrity": "sha512-Lq5iqQwi2kWpRu+H624t0gubdSmtOvnQUp7xBKRr8aNMiT5DkaRWYnjks0XYD9qXKmnZID6e01wYOclXRGj5FA==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+            "integrity": "sha512-5uPOZS1EDeuBIFwTYTlJefbQXWn+auebcRQpj5EtWr9E/7XwWVZ6YTgulZVSTHAEU9y/mYMYh2Mjt7TJ1iRNxQ==",
             "requires": {
                 "async": "~0.2.6",
-                "optimist": "~0.3.5",
-                "source-map": "~0.1.7",
-                "uglify-to-browserify": "~1.0.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
-                "source-map": {
-                    "version": "0.1.43",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                    "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
-                    "requires": {
-                        "amdefine": ">=0.0.4"
-                    }
+                "async": {
+                    "version": "0.2.10",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
                 }
             }
         },
@@ -13895,14 +11114,6 @@
                 }
             }
         },
-        "uid-safe": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-            "integrity": "sha512-MHTGzIDNPv1XhDK0MyKvEroobUhtpMa649/9SIFbTRO2dshLctD3zxOwQw+gQ+Mlp5osfMdUU1sjcO6Fw4rvCA==",
-            "requires": {
-                "random-bytes": "~1.0.0"
-            }
-        },
         "unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -13913,11 +11124,6 @@
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
             }
-        },
-        "unc-path-regex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg=="
         },
         "uncontrollable": {
             "version": "4.1.0",
@@ -13930,12 +11136,17 @@
         "underscore": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-            "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+            "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ=="
         },
         "underscore.string": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
             "integrity": "sha512-4FNx1KnBckIW9Z7XvptVBzhWZvyuaB9NC3fdqdAp6GIRY4r6eDAENOZx2dzPrriQVZctkTYw2J7Vi1vjHS2E3A=="
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "union-value": {
             "version": "1.0.1",
@@ -13957,11 +11168,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
             "integrity": "sha512-mZdDpf3vBV5Efh29kMw5tXoup/buMgxLzOt/XKFKcVmi+15ManNQWr6HfZ2aiZTYlYixbdNJ0KFmIZIv52tHSQ=="
-        },
-        "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha512-L8KM6TdpsoBk6TJTXevbmpub3bATS06Znu3BcfVPVQkFtnh1MFeCZ3gFKCQcji7f7YYiigsO5OR99vqhoNT8nQ=="
         },
         "universalify": {
             "version": "0.1.2",
@@ -14043,7 +11249,7 @@
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+            "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg=="
         },
         "url": {
             "version": "0.11.3",
@@ -14060,9 +11266,9 @@
                     "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
                 },
                 "qs": {
-                    "version": "6.12.0",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-                    "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+                    "version": "6.12.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+                    "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
                     "requires": {
                         "side-channel": "^1.0.6"
                     }
@@ -14093,36 +11299,6 @@
             "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
             "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ=="
         },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha512-aggiKfEEubv3UwRNqTzLInZpAOmKzwdHqEBmW/hBA/mt99eg+b4VrX6i+IRLxU8+WJYfa33rGwRseg4eElUgsQ=="
-        },
-        "useragent": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
-            "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
-            "requires": {
-                "lru-cache": "4.1.x",
-                "tmp": "0.0.x"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "4.1.5",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-                    "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
-                    }
-                },
-                "yallist": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                    "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
-                }
-            }
-        },
         "util": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -14143,23 +11319,10 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
-        "utile": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
-            "integrity": "sha512-ltfvuCJNa/JFOhKBBiQ9qDyyFwLstoMMO1ru0Yg/Mcl8dp1Z3IBaL7n+5dHpyma+d3lCogkgBQnWKtGxzNyqhg==",
-            "requires": {
-                "async": "~0.2.9",
-                "deep-equal": "*",
-                "i": "0.3.x",
-                "mkdirp": "0.x.x",
-                "ncp": "0.4.x",
-                "rimraf": "2.x.x"
-            }
-        },
         "utils-merge": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-            "integrity": "sha512-HwU9SLQEtyo+0uoKXd1nkLqigUWLB+QuNQR4OcmB73eWqksM5ovuqcycks2x043W8XVb75rG1HQ0h93TMXkzQQ=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
         },
         "uuid": {
             "version": "8.3.1",
@@ -14171,14 +11334,6 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
             "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw=="
         },
-        "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha512-SKfhk/LlaXzvtowJabLZwD4K6SGRYeoxA7KJeISlUMAB/NT4CBkZjMq3WceX2Ckm4llwqYVo8TICgsDYCBU2tA==",
-            "requires": {
-                "user-home": "^1.1.1"
-            }
-        },
         "validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -14189,9 +11344,9 @@
             }
         },
         "vary": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-            "integrity": "sha512-yNsH+tC0r8quK2tg/yqkXqqaYzeKTkSqQ+8T6xCoWgOi/bU/omMYz+6k+I91JJJDeltJzI7oridTOq6OYkY0Tw=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
         },
         "vendors": {
             "version": "1.0.4",
@@ -14212,72 +11367,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                     "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-                }
-            }
-        },
-        "vhost": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
-            "integrity": "sha512-S3pJdWrpFWrKMboRU4dLYgMrTgoPALsmYwOvyebK2M6X95b9kQrjZy5rwl3uzzpfpENe/XrNYu/2U+e7/bmT5g=="
-        },
-        "vinyl": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-            "integrity": "sha512-P5zdf3WB9uzr7IFoVQ2wZTmUwHL8cMZWJGzLBNCHNZ3NB6HTMsYABtt7z8tAGIINLXyAob9B9a1yzVGMFOYKEA==",
-            "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
-                "replace-ext": "0.0.1"
-            }
-        },
-        "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha512-9CTKjt8378nhdydwFDTwywKio0n8aqq6xA70g0uypcnTNSCow/gQOwv0L9E2GaKd7EQ3kZl/diBxPSCgcBXESw==",
-            "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha512-g62n3Kb9cszeZvmvBUqP/dsEJD/+80pDA8u8KqHnAPrVnQ2Je9rVV6opxkhuWCd1kCn2gOibzDKxCtBvD3q5kA=="
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-                    "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha512-pmza4M5VA15HOImIQYWhoXGlGNafCm0QK5BpBUXkzzEwrRxKqBsbAhTfkT2zMcJhUX1G1Gkid0xaV8WjOl7DsA==",
-                    "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
-                    }
                 }
             }
         },
@@ -14303,75 +11392,6 @@
                 "graceful-fs": "^4.1.2",
                 "neo-async": "^2.5.0",
                 "watchpack-chokidar2": "^2.0.1"
-            },
-            "dependencies": {
-                "anymatch": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-                    "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-                    "optional": true,
-                    "requires": {
-                        "normalize-path": "^3.0.0",
-                        "picomatch": "^2.0.4"
-                    }
-                },
-                "binary-extensions": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-                    "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-                    "optional": true
-                },
-                "chokidar": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-                    "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-                    "optional": true,
-                    "requires": {
-                        "anymatch": "~3.1.2",
-                        "braces": "~3.0.2",
-                        "fsevents": "~2.3.2",
-                        "glob-parent": "~5.1.2",
-                        "is-binary-path": "~2.1.0",
-                        "is-glob": "~4.0.1",
-                        "normalize-path": "~3.0.0",
-                        "readdirp": "~3.6.0"
-                    }
-                },
-                "fsevents": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-                    "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-                    "optional": true
-                },
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                },
-                "is-binary-path": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-                    "optional": true,
-                    "requires": {
-                        "binary-extensions": "^2.0.0"
-                    }
-                },
-                "normalize-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-                    "optional": true
-                },
-                "readdirp": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-                    "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-                    "optional": true,
-                    "requires": {
-                        "picomatch": "^2.2.1"
-                    }
-                }
             }
         },
         "watchpack-chokidar2": {
@@ -14403,6 +11423,12 @@
                             }
                         }
                     }
+                },
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+                    "optional": true
                 },
                 "braces": {
                     "version": "2.3.2",
@@ -14476,6 +11502,15 @@
                         }
                     }
                 },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "optional": true,
+                    "requires": {
+                        "nan": "^2.12.1"
+                    }
+                },
                 "glob-parent": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -14495,6 +11530,15 @@
                                 "is-extglob": "^2.1.0"
                             }
                         }
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
                     }
                 },
                 "is-number": {
@@ -14517,6 +11561,18 @@
                         }
                     }
                 },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+                    "optional": true
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "optional": true
+                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -14538,11 +11594,46 @@
                         "to-regex": "^3.0.2"
                     }
                 },
-                "normalize-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                "readable-stream": {
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+                    "optional": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                     "optional": true
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
                 },
                 "to-regex-range": {
                     "version": "2.1.1",
@@ -14608,14 +11699,6 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
                     "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
                 },
-                "async": {
-                    "version": "2.6.4",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-                    "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-                    "requires": {
-                        "lodash": "^4.17.14"
-                    }
-                },
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -14651,20 +11734,10 @@
                         "locate-path": "^2.0.0"
                     }
                 },
-                "graceful-fs": {
-                    "version": "4.2.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-                    "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-                },
                 "has-flag": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
                     "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng=="
-                },
-                "interpret": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
@@ -14804,13 +11877,6 @@
                 "path-is-absolute": "^1.0.0",
                 "range-parser": "^1.0.3",
                 "time-stamp": "^2.0.0"
-            },
-            "dependencies": {
-                "time-stamp": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.2.0.tgz",
-                    "integrity": "sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA=="
-                }
             }
         },
         "webpack-dev-server": {
@@ -14865,6 +11931,11 @@
                             }
                         }
                     }
+                },
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
                 },
                 "braces": {
                     "version": "2.3.2",
@@ -14956,6 +12027,15 @@
                         }
                     }
                 },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "optional": true,
+                    "requires": {
+                        "nan": "^2.12.1"
+                    }
+                },
                 "glob-parent": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -14979,6 +12059,14 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
                     "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
@@ -15006,6 +12094,16 @@
                         }
                     }
                 },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -15026,10 +12124,34 @@
                         "to-regex": "^3.0.2"
                     }
                 },
-                "normalize-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+                "readable-stream": {
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 },
                 "string-width": {
                     "version": "1.0.2",
@@ -15039,6 +12161,14 @@
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
                         "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "supports-color": {
@@ -15149,17 +12279,6 @@
                 "is-symbol": "^1.0.3"
             }
         },
-        "which-collection": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-            "requires": {
-                "is-map": "^2.0.3",
-                "is-set": "^2.0.3",
-                "is-weakmap": "^2.0.2",
-                "is-weakset": "^2.0.3"
-            }
-        },
         "which-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
@@ -15196,9 +12315,9 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
         },
         "wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+            "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
         },
         "wrap-ansi": {
             "version": "2.1.0",
@@ -15232,7 +12351,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "write": {
             "version": "1.0.3",
@@ -15242,26 +12361,10 @@
                 "mkdirp": "^0.5.1"
             }
         },
-        "ws": {
-            "version": "0.4.32",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
-            "integrity": "sha512-htqsS0U9Z9lb3ITjidQkRvkLdVhQePrMeu475yEfOWkAYvJ6dSjQp1tOH6ugaddzX5b7sQjMPNtY71eTzrV/kA==",
-            "requires": {
-                "commander": "~2.1.0",
-                "nan": "~1.0.0",
-                "options": ">=0.0.5",
-                "tinycolor": "0.x"
-            }
-        },
         "xml-char-classes": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
             "integrity": "sha512-dTaaRwm4ccF8UF15/PLT3pNNlZP04qko/FUcr0QBppYLk8+J7xA9gg2vI2X4Kr1PcJAVxwI9NdADex29FX2QVQ=="
-        },
-        "xmlhttprequest": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
-            "integrity": "sha512-WTsthd44hTdCRrHkdtTgbgTKIJyNDV+xiShdooFZBUstY7xk+EXMx/u5gjuUXaCiCWvtBVCHwauzml2joevB4w=="
         },
         "xtend": {
             "version": "4.0.2",
@@ -15311,11 +12414,6 @@
                     "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg=="
                 }
             }
-        },
-        "zeparser": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
-            "integrity": "sha512-Qj4lJIRPy7hIW1zCBqwA3AW8F9uHswVoXPnotuY6uyNgbg5qGb6SJfWZi+YzD3DktbUnUoGiGZFhopbn9l1GYw=="
         }
     }
 }

--- a/server/features/ingest_planning.feature
+++ b/server/features/ingest_planning.feature
@@ -469,7 +469,7 @@ Feature: Ingest STT Planning items
                 "planning": {
                     "g2_content_type": "text",
                     "scheduled": "2017-12-25T09:16:43+0000",
-                    "headline": "Parliament passed the Alcohol Act and the government gained confidence*** TRANSLATED ***",
+                    "slugline": "Parliament passed the Alcohol Act and the government gained confidence*** TRANSLATED ***",
                     "genre": [{"name": "P\u00e4\u00e4juttu", "qcode": "1"}],
                     "subject": [
                         {"name": "Politics", "qcode": "9", "scheme": "sttdepartment"},

--- a/server/stt/signal_hooks.py
+++ b/server/stt/signal_hooks.py
@@ -191,9 +191,15 @@ def before_content_published(_sender: Any, item: Dict[str, Any], updates: Dict[s
             "news_coverage_status": get_coverage_status_from_cv("ncostat:int"),
             "flags": {},
         }
-        for field in ["genre", "headline", "language", "slugline", "subject"]:
+        for field in ["genre", "language", "subject"]:
             if item.get(field):
                 new_coverage["planning"][field] = item[field]
+
+        if item.get("slugline", "").strip():
+            new_coverage["planning"]["slugline"] = item["slugline"].strip()
+        elif item.get("headline", "").strip():
+            new_coverage["planning"]["slugline"] = item["headline"].strip()
+
         _update_coverage_assignment_details(new_coverage, item)
 
         # Remove placeholder text coverage and add the new one


### PR DESCRIPTION
Keeping in line with the same logic used in the parent PlanningMLParser (headline is not actually stored on ingest, just slugline, see https://github.com/superdesk/superdesk-planning/blob/develop/server/planning/feed_parsers/superdesk_planning_xml.py#L228)