### PR TITLE
[STT-47] - Fix parser to store location details as a string

### DIFF
--- a/server/stt/stt_events_ml.py
+++ b/server/stt/stt_events_ml.py
@@ -216,7 +216,7 @@ class STTEventsMLParser(EventsMLParser):
         location = {"address": {"extra": {}}}
 
         if notes is not None:
-            location["details"] = [notes]
+            location["details"] = notes
 
         try:
             poi_name_el = location_xml.find(self.qname("name"))

--- a/server/tests/events_ml_parser_test.py
+++ b/server/tests/events_ml_parser_test.py
@@ -50,7 +50,7 @@ class STTEventsMLParserTest(TestCase):
         self.assertEqual(location["address"]["extra"]["sttcountry"], "1")
         self.assertEqual(location["address"]["extra"]["iso3166"], "iso3166-1a2:FI")
         self.assertEqual(location["address"]["line"][0], "Eteläinen Rautatiekatu 4")
-        self.assertEqual(location["details"], ["Knock 3 times"])
+        self.assertEqual(location["details"], "Knock 3 times")
 
 
 class STTEventsMLParserEventTypeCVTest(TestCase):


### PR DESCRIPTION
### Purpose

This PR updates the event ingestion pipeline to store `location.details` as a string instead of a single-element array. 

### What has changed
- In the parser, changed the assignment to store it as a string

Resolves: #[STT-47]


[STT-47]: https://sofab.atlassian.net/browse/STT-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ