### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: "CI"
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   server:


### PR DESCRIPTION
Potential fix for [https://github.com/superdesk/superdesk-stt/security/code-scanning/7](https://github.com/superdesk/superdesk-stt/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow uses reusable workflows, we will assume that the reusable workflows handle their specific permissions. Therefore, we will set the root permissions to `contents: read`, which is a safe default for most workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
