### PR TITLE
 add Lupaus/Päivälista templates + event enrichment; rename filters

### DIFF
--- a/server/data/planning_export_templates.json
+++ b/server/data/planning_export_templates.json
@@ -5,8 +5,19 @@
     "name": "paivalista_events_list",
     "type": "event",
     "data": {
-      "body_html_template": "paivalista_events_template.html"
+      "body_html_template": "paivalista_events_template.html",
+      "headline_template": "paivalista_events_headline.html"
     },
-    "label": "Päivälista events Template"
+    "label": "Päivälista Template"
+  },
+  {
+    "_id": "lupaus_list",
+    "init_version": 1,
+    "name": "lupaus_list",
+    "type": "planning",
+    "data": {
+      "body_html_template": "lupaus_events_template.html"
+    },
+    "label": "Lupaus Template"
   }
 ]

--- a/server/settings.py
+++ b/server/settings.py
@@ -141,7 +141,9 @@ INSTALLED_APPS = [
     "stt.macros",
     "stt.search_providers.newshub",
     "stt.ai_proxy",
-    "stt.paivalista_filters",
+    "stt.template_filters",
+    "stt.paivalista_export",
+    "stt.lupaus_export",
     "stt.io.feed_parsers.stt_events_csv_parse",
 ]
 

--- a/server/stt/lupaus_export/__init__.py
+++ b/server/stt/lupaus_export/__init__.py
@@ -1,0 +1,4 @@
+def init_app(app):
+    from .enrich_related import enrich_planning_agendas
+
+    app.jinja_env.globals.update(enrich_planning_agendas=enrich_planning_agendas)

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -1,0 +1,210 @@
+from typing import Dict, List, Any, Set
+from flask import current_app
+from superdesk import get_resource_service
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _collect_event_ids(agendas: List[Dict[str, Any]]) -> List[str]:
+    """
+    Extract unique related event identifiers from a collection of agendas.
+
+    This function walks through each agenda's "items" and each item's
+    "related_events", collecting the first available identifier from the keys
+    "_id", "event", "event_id", or "guid". Collected identifiers are coerced to
+    strings and deduplicated.
+
+    - Accepts `agendas` as None or an empty list.
+    - Silently tolerates missing or malformed structures.
+    - The order of returned IDs is undefined.
+
+    Args:
+        agendas: A list of agenda dictionaries. Each agenda may include an "items"
+            list; each item may include a "related_events" list of mappings.
+
+    Returns:
+        A list of unique event identifier strings extracted from related events.
+
+    Example:
+        >>> agendas = [
+        ...     {"items": [{"related_events": [{"_id": 1}, {"event": "a"}]}]},
+        ...     {"items": [{"related_events": [{"event_id": 1}, {"guid": "b"}]}]},
+        ... ]
+        >>> sorted(_collect_event_ids(agendas))
+        ['1', 'a', 'b']
+    """
+    ids: Set[str] = set()
+    for ag in agendas or []:
+        for pl in ag.get("items") or []:
+            for re in pl.get("related_events") or []:
+                # tolerate various shapes
+                for key in ("_id", "event", "event_id", "guid"):
+                    val = re.get(key)
+                    if val:
+                        ids.add(str(val))
+                        break
+    return list(ids)
+
+
+def _apply_projection_locally(
+    docs: List[Dict[str, Any]], projection: Dict[str, int] | None
+) -> List[Dict[str, Any]]:
+    """
+    Apply a MongoDB-like inclusion projection to a list of documents.
+
+    Given a list of dictionaries, return a new list where each document
+    contains only the fields whose entry in `projection` is truthy (e.g., 1 or True).
+    If `projection` is None or empty, the original list is returned unchanged.
+
+    Notes:
+    - Only inclusion projections are supported. Setting a field to 0/False has no effect
+        (the field is simply not included in the result).
+    - If '_id' is present in `projection` with a truthy value, it will be included;
+        otherwise it is omitted even if present in the input documents.
+    - Fields requested in `projection` that do not exist in a document are ignored.
+    - Input documents are not mutated; new, shallow dictionaries are created.
+
+    Parameters:
+            docs: List of input documents (dicts).
+            projection: Mapping of field names to inclusion flags (1/True to include, 0/False/absent to omit).
+
+    Returns:
+            A list of new documents containing only the projected fields. If `projection` is falsy,
+            the original `docs` list is returned as-is.
+
+    Examples:
+            >>> docs = [{'a': 1, 'b': 2, '_id': 'x'}, {'a': 3, 'c': 4}]
+            >>> _apply_projection_locally(docs, {'a': 1})
+            [{'a': 1}, {'a': 3}]
+            >>> _apply_projection_locally(docs, {'a': 1, '_id': 1})
+            [{'a': 1, '_id': 'x'}, {'a': 3}]
+            >>> _apply_projection_locally(docs, None) is docs
+            True
+    """
+    if not projection:
+        return docs
+    keep = {k for k, v in projection.items() if v}
+    # Always keep _id if requested implicitly
+    if "_id" in projection and projection["_id"]:
+        keep.add("_id")
+    return [{k: d.get(k) for k in keep if k in d} for d in docs]
+
+
+def _find_many(
+    resource: str, lookup: Dict[str, Any], projection: Dict[str, int] | None = None
+) -> List[Dict[str, Any]]:
+    """
+    Try service.get_from_mongo with various signatures; fall back to service.get;
+    and only if that fails, go to data layer without projection. If we can't push
+    'projection' to the DB, we'll trim the fields locally.
+    """
+    # Prefer resource service
+    try:
+        svc = get_resource_service(resource)
+    except Exception as e:
+        logger.exception(
+            "Error using service for %s (%s: %s).",
+            resource,
+            e.__class__.__name__,
+            e,
+        )
+        svc = None
+
+    # 1) service.get_from_mongo with (req=None, ...)
+    if svc and hasattr(svc, "get_from_mongo"):
+        try:
+            docs = list(svc.get_from_mongo(None, lookup=lookup, projection=projection))
+            if docs is not None:
+                return _apply_projection_locally(docs, projection)
+        except TypeError:
+            # Signature mismatch; fall through to other strategies
+            pass
+        except Exception as e:
+            logger.exception(
+                "Error in _find_many service.get_from_mongo with (req=None, ...) using service for %s (%s: %s).",
+                resource,
+                e.__class__.__name__,
+                e,
+            )
+            # Fall through to other strategies
+            pass
+
+    # 2) service.get (no projection)
+    if svc and hasattr(svc, "get"):
+        try:
+            docs = list(svc.get(None, lookup))
+            return _apply_projection_locally(docs, projection)
+        except Exception as e:
+            logger.exception(
+                "Error in _find_many service.get (no projection) using service for %s (%s: %s).",
+                resource,
+                e.__class__.__name__,
+                e,
+            )
+            pass
+
+    # 3) Eve data layer (no projection kwarg supported in your build)
+    try:
+        cursor = current_app.data.find(resource, req=None, lookup=lookup)
+        docs = list(cursor)
+        logger.info("Using Eve data layer (no projection)")
+        return _apply_projection_locally(docs, projection)
+    except Exception as e:
+        logger.exception(
+            "Error in _find_many Eve data layer (no projection) using service for %s (%s: %s).",
+            resource,
+            e.__class__.__name__,
+            e,
+        )
+        return []
+
+
+def enrich_planning_agendas(agendas: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Adds item.related_events_expanded = [event, ...]
+    Each event has at least: _id, name, dates, location (resolved if IDs).
+    """
+    ev_ids = _collect_event_ids(agendas)
+    logger.info(f"Enriching agendas: found {len(ev_ids)} unique related event IDs")
+    logger.info(f"Enriching agendas: event IDs: {ev_ids}")
+    if not ev_ids:
+        return agendas
+
+    # Search events by _ids
+    events = _find_many(
+        "events",
+        {"_id": {"$in": ev_ids}},
+        projection={
+            "_id": 1,
+            "name": 1,
+            "dates": 1,
+            "location": 1,
+            "language": 1,
+        },
+    )
+    logger.info(f"Enriching agendas: found {len(events)} events")
+    if not events:
+        # No matches → leave empty but return agendas intact
+        for ag in agendas or []:
+            for pl in ag.get("items") or []:
+                pl["related_events_expanded"] = []
+        return agendas
+
+    # Map by both _id and guid for resilience
+    by_key: Dict[str, Dict[str, Any]] = {}
+    for e in events:
+        if "_id" in e:
+            by_key[str(e["_id"])] = e
+    # Attach to each planning item
+    for ag in agendas or []:
+        for pl in ag.get("items") or []:
+            expanded: List[Dict[str, Any]] = []
+            for re in pl.get("related_events") or []:
+                key = re.get("_id")
+                ev = by_key.get(str(key)) if key else None
+                if ev:
+                    expanded.append(ev)
+            pl["related_events_expanded"] = expanded
+
+    return agendas

--- a/server/stt/paivalista_export/__init__.py
+++ b/server/stt/paivalista_export/__init__.py
@@ -1,0 +1,6 @@
+def init_app(app):
+    from .common import format_paivalista_for_export
+
+    app.jinja_env.globals.update(
+        format_paivalista_for_export=format_paivalista_for_export
+    )

--- a/server/stt/paivalista_export/common.py
+++ b/server/stt/paivalista_export/common.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class Formatted:
+    rows: List[Dict[str, Any]]
+
+
+def format_paivalista_for_export(items):
+    rows = items or []
+    # TODO: sorting etc. if needed
+    # item keys are:
+    # ['type',
+    # 'occur_status',
+    # 'dates',
+    # 'calendars',
+    # 'state',
+    # 'language',
+    # 'languages',
+    # 'place',
+    # 'files',
+    # '_time_to_be_confirmed',
+    # 'slugline',
+    # 'name',
+    # 'definition_short',
+    # 'location',
+    # 'links',
+    # '_updated',
+    # '_created',
+    # 'guid',
+    # 'original_creator',
+    # 'firstcreated',
+    # 'versioncreated',
+    # '_planning_schedule',
+    # '_etag',
+    # 'lock_action',
+    # 'lock_user',
+    # 'lock_time',
+    # 'lock_session',
+    # 'state_reason',
+    # 'pubstatus',
+    # 'actioned_date',
+    # 'firstpublished',
+    # '_id',
+    # '_type',
+    # 'plannings',
+    # 'coverages',
+    # 'published_archive_items',
+    # 'assignees',
+    # 'text_assignees',
+    # 'contacts',
+    # 'description_text',
+    # 'schedule']
+
+    return {"rows": rows}

--- a/server/stt/template_filters/__init__.py
+++ b/server/stt/template_filters/__init__.py
@@ -1,5 +1,5 @@
 """
-Register two custom Jinja filters – fi_date and fi_time – so they are
+Register custom Jinja filters – fi_date, fi_time and fi_ddmm – so they are
 available in every template rendered by Superdesk.
 """
 
@@ -46,6 +46,14 @@ def fi_time(value: str) -> str:
     return dt.strftime("%H:%M")
 
 
+def fi_ddmm(value: str) -> str:
+    dt = _to_helsinki(value)
+    if not dt:
+        return ""
+    return f"{dt.day:02d}.{dt.month:02d}."
+
+
 def init_app(app):
     app.jinja_env.filters["fi_date"] = fi_date
     app.jinja_env.filters["fi_time"] = fi_time
+    app.jinja_env.filters["fi_ddmm"] = fi_ddmm

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -1,0 +1,33 @@
+{# ---------------------------------------- #}
+{#   lupaus_events_template.html            #}
+{# ---------------------------------------- #}
+
+{# Enrich agendas with related events (adds item.related_events_expanded) #}
+{% set agendas = enrich_planning_agendas(agendas) %}
+
+{% macro lupaus_location(location) -%}
+    {%- set loc = location[0] if location and location[0] and location[0].address else None -%}
+    {%- if loc -%}
+        {{- (loc.address.name or loc.name) -}}
+    {%- endif -%}
+{%- endmacro %}
+
+{# One paragraph per agenda item #}
+{%- for agenda in agendas or [] -%}
+    {%- for item in agenda['items'] | default([]) -%}
+        {%- set bits = [] -%}
+        {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
+        {%- if item.description_text %}{% set _ = bits.append(item.description_text) %}{% endif -%}
+        {%- for ev in item.related_events_expanded or [] -%}
+        {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
+        {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
+        {%- if ev.location is iterable -%}
+            {%- set ev_loc = lupaus_location(ev.location) -%}
+            {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
+        {%- endif -%}
+        {%- endfor -%}
+        {%- if bits %}<p>{{- bits | join(', ') -}}</p>{% endif -%}
+        {# add empty line between items #}
+        <p></p>
+    {%- endfor -%}
+{%- endfor -%}

--- a/server/templates/paivalista_events_headline.html
+++ b/server/templates/paivalista_events_headline.html
@@ -1,0 +1,5 @@
+{% set first_start = (items
+  | selectattr('dates','defined')
+  | selectattr('dates.start','defined')
+  | map(attribute='dates.start') | list | sort | first) %}
+Päivälista {{ first_start|fi_ddmm if first_start else '' }}

--- a/server/templates/paivalista_events_template.html
+++ b/server/templates/paivalista_events_template.html
@@ -2,11 +2,13 @@
    paivalista_events_template.html
 # ---------------------------------------- #}
 
+{% set formatted = format_paivalista_for_export(items) %}
+
 {#-- A helper macro: replicates printPaivalistaLocation --#}
 {% macro paivalista_location(location) -%}
-    {%- set loc = location[0] if location and location[0].address.title else None -%}
+    {%- set loc = location[0] if location and location[0].address.name else None -%}
     {%- if loc %}
-        {{- loc.address.title -}}
+        {{- loc.address.name -}}
         {%- if loc.address.line and loc.address.line[0].strip() -%}, {{ loc.address.line[0] }}{%- endif -%}
         {%- if loc.address.city -%}, {{ loc.address.city }}{%- endif -%}
     {%- endif -%}
@@ -14,7 +16,7 @@
 
 {#-- MAIN LOOP — sort first, then print a <h3> when the day changes --#}
 {% set ns = namespace(cur='') %}
-{% for item in items|selectattr('dates','defined')|sort(attribute='dates.start') %}
+{% for item in formatted.rows | selectattr('dates','defined') | sort(attribute='dates.start') %}
     {%- set day  = item.dates.start | fi_date %}
     {%- if ns.cur != day %}
         {%- set ns.cur = day %}
@@ -27,8 +29,8 @@
     {% endif %}
 
     {# Short definition --------------------------------------------------- #}
-    {% if item.definitionShort %}
-        <p>{{ item.definitionShort }}</p>
+    {% if item.definition_short %}
+        <p>{{ item.definition_short }}</p>
     {% endif %}
 
     {# Location ----------------------------------------------------------- #}
@@ -38,7 +40,7 @@
     {% endif %}
 
     {# Registration details (already HTML, keep it “safe”) ---------------- #}
-    {{ item.registrationDetails | safe }}
+    {{ item.registration_details | safe }}
 
     <p></p>   {# blank line exactly like the TS version - kept for parity #}
 {% endfor %}


### PR DESCRIPTION
* Update planning_export_templates.json to register new templates
* Add lupaus_export with enrich_related (expands related_events + logging)
* Add paivalista_export package with common helpers
* Rename paivalista_filters -> template_filters; register fi_date/fi_time; handle datetime inputs
* Add templates: lupaus_events_template.html, paivalista_events_headline.html
* Tweak paivalista_events_template.html formatting/whitespace