### PR TITLE
fix issue dateline string to dict to STT-85

### DIFF
--- a/server/stt/stt_parse_businesswire.py
+++ b/server/stt/stt_parse_businesswire.py
@@ -49,12 +49,14 @@ class BusinessWireParser(NewsMLOneFeedParser):
         if byline:
             item["byline"] = byline.strip()
 
-        # Extract Dateline
+        # Extract Dateline (Superdesk expects an object with a text field)
         dateline = xml.findtext(
             "NewsItem/NewsComponent/NewsComponent/NewsLines/DateLine"
         )
         if dateline:
-            item["dateline"] = dateline.strip()
+            txt = dateline.strip()
+            if txt:
+                item["dateline"] = {"text": txt}
 
         components = xml.findall("NewsItem/NewsComponent/NewsComponent/NewsComponent")
         for component in components:

--- a/server/tests/stt_parse_businesswire_test.py
+++ b/server/tests/stt_parse_businesswire_test.py
@@ -43,11 +43,11 @@ class BusinessWireParserTestCase(TestCase):
 
     def test_slugline_and_byline(self):
         assert self.item["slugline"] == "CA-MIRUM-PHARMACEUTICALS"
-        # ByLine is empty in the test XML fixture
-        assert self.item["byline"] == ""
+        # ByLine is empty in the test XML fixture; key may be missing if empty
+        assert self.item.get("byline", "") == ""
 
     def test_dateline_and_subjects(self):
-        assert self.item["dateline"] == "FOSTER CITY, Calif."
+        assert self.item["dateline"]["text"] == "FOSTER CITY, Calif."
         # Subject is not present in the test XML fixture
         assert "subject" not in self.item or len(self.item.get("subject", [])) == 0
 


### PR DESCRIPTION
fix issue dateline

```
System Error [3000] on ingest provider Business Wire: xception', 'reason': 'object mapping for [dateline] tried to parse field [dateline] as object, but found a concrete value'}, 'data': {'original_source': 'Q4 Inc.', 'priority': 6, 'guid': '20240606612150', 'version': '1', 'dateline': 'TORONTO', 'headline': 'Q4 Inc. ….
```