### PR TITLE
[STT-1214] - Map sttsource to the source field in the newsroom ninjs output

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -129,6 +129,7 @@ INSTALLED_APPS = [
     "stt.macros",
     "stt.search_providers.newshub",
     "stt.ai_proxy",
+    "stt.stt_newsroom_ninjs_formatter",
 ]
 
 MODULES.append("planning")

--- a/server/stt/stt_newsroom_ninjs_formatter.py
+++ b/server/stt/stt_newsroom_ninjs_formatter.py
@@ -1,0 +1,45 @@
+import logging
+
+from superdesk.publish.formatters import NewsroomNinjsFormatter
+
+logger = logging.getLogger(__name__)
+
+
+class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
+    name = "STT Newsroom NINJS"
+    type = "stt newsroom ninjs"
+
+    def __init__(self):
+        self.can_preview = False
+        self.can_export = False
+        self.internal_renditions = ["original", "viewImage", "baseImage"]
+
+    def update_ninjs_stt_sources(self, ninjs):
+        try:
+            stt_sources = [
+                subj["name"]
+                for subj in ninjs.get("subject", [])
+                if subj.get("scheme") == "sttsource"
+            ]
+
+            if not stt_sources:
+                ninjs["source"] = "STT"
+                return
+
+            # Remove duplicates and sort with STT being first, then alphabetical order
+            unique_sources = list(set(stt_sources))
+            if "STT" in unique_sources:
+                unique_sources.remove("STT")
+                sorted_sources = ["STT"] + sorted(unique_sources, key=str.lower)
+            else:
+                sorted_sources = sorted(unique_sources, key=str.lower)
+
+            ninjs["source"] = ", ".join(sorted_sources)
+        except Exception as e:
+            logger.error(f"Error occurred when updating ninjs stt sources: {str(e)}")
+
+    async def _transform_to_ninjs(self, article, subscriber, recursive=True):
+        ninjs = await super()._transform_to_ninjs(article, subscriber, recursive)
+        self.update_ninjs_stt_sources(ninjs)
+
+        return ninjs

--- a/server/tests/fixtures/stt_newsml_creditline_test.xml
+++ b/server/tests/fixtures/stt_newsml_creditline_test.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<newsItem xmlns:stt="http://www.stt-lehtikuva.fi/NewsML" xmlns="http://iptc.org/std/nar/2006-10-01/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" guid="urn:newsml:stt.fi:20170131:101159383" version="1" standardversion="2.12" conformance="power" xml:lang="fi-FI" standard="NewsML-G2" xsi:schemaLocation="http://iptc.org/std/nar/2006-10-01/ http://www.iptc.org/std/NewsML-G2/2.12/specification/NewsML-G2_2.12-spec-All-Power.xsd http://www.stt-lehtikuva.fi/NewsML http://www.stt-lehtikuva.fi/newsml/schema/STT-Lehtikuva_NewsML_G2.xsd" stt:formatversion="1.1">
+  <catalogRef href="http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_19.xml"/>
+  <catalogRef href="http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_18.xml"/>
+  <catalogRef href="http://www.stt-lehtikuva.fi/newsml/doc/stt-NewsCodesCatalog_1.xml"/>
+  <itemMeta>
+    <itemClass qcode="ninat:text"/>
+    <provider literal="STT"/>
+    <versionCreated>2025-09-08T10:01:00+00:00</versionCreated>
+    <firstCreated/>
+    <pubStatus qcode="stat:usable"/>
+    <link rel="irel:seeAlso" residref="urn:newsml:stt.fi:20190521:1029362" contenttype="image/jpeg">
+        <title role="drol:caption">Kauppaministeriön mukaan 90 päivän lisäaika tarvitaan, jotta Huawei ja sen kumppanit ehtivät sopeutua muutokseen. LEHTIKUVA/AFP </title>
+        <filename>1029359.jpg</filename>
+    </link>
+  </itemMeta>
+  <contentMeta>
+    <urgency>3</urgency>
+    <contentCreated>2025-09-08T10:03:00+00:00</contentCreated>
+    <contentModified>2025-09-08T10:03:00+00:00</contentModified>
+    <creator qcode="stteditorid:26634">
+      <name>Areva Mari</name>
+    </creator>
+    <altId type="sttidtype:textid">117616079</altId>
+    <located type="loctyp:City">
+      <name/>
+    </located>
+    <rating value="4" scalemin="1" scalemax="9" scaleunit="rscaleunit:number" ratingtype="sttrating:webprio"/>
+    <subject type="cpnat:abstract" literal="Related topic id" qcode="stt-topics:490933"/>
+    <subject type="cpnat:abstract" literal="Event id related to topic" qcode="stt-events:213870"/>
+    <subject type="cpnat:abstract" qcode="sttdepartment:9">
+      <name>Politiikka</name>
+    </subject>
+    <subject type="cpnat:geoArea" qcode="sttlocationalias:7576"/>
+    <subject type="cpnat:geoArea" qcode="sttlocationalias:8975"/>
+    <subject type="cpnat:abstract" qcode="sttsubj:11000000">
+      <name>Politiikka</name>
+    </subject>
+    <subject type="cpnat:abstract" qcode="sttsubj:11002000">
+      <name>Diplomatia Ulkopolitiikka</name>
+    </subject>
+    <subject type="cpnat:abstract" qcode="sttsubj:11000000">
+      <name>Politiikka</name>
+    </subject>
+    <subject type="cpnat:abstract" qcode="sttsubj:11006000">
+      <name>Julkinen hallinto</name>
+    </subject>
+    <subject type="cpnat:abstract" qcode="sttsubj:11006009">
+      <name>Ministerit</name>
+    </subject>
+    <subject type="cpnat:abstract" qcode="sttsubj:11000000">
+      <name>Politiikka</name>
+    </subject>
+    <subject type="cpnat:abstract" qcode="sttsubj:11006000">
+      <name>Julkinen hallinto</name>
+    </subject>
+    <subject type="cpnat:abstract" qcode="sttsubj:11006006">
+      <name>Valtionpäämiehet</name>
+    </subject>
+    <subject type="cpnat:abstract" qcode="sttsubj:06000000">
+      <name>Ympäristö</name>
+    </subject>
+    <slugline/>
+    <dateline/>
+    <by/>
+    <description role="drol:summary"/>
+    <headline>Test Headline for STT Source Mapping - Part 2</headline>
+    <creditline>STT–AFP</creditline>
+    <genre qcode="sttgenre:1">
+      <name>Pääjuttu</name>
+    </genre>
+    <genre qcode="sttversion:5">
+      <name>Loppuversio</name>
+      <related qcode="sttrel:actuallength" value="1882"/>
+    </genre>
+    <genre qcode="sttdescription:imagetype" literal="Imagetype ID">
+      <name>20</name>
+    </genre>
+    <genre qcode="sttdescription:imagetypename" literal="Imagetype NAME">
+      <name>Kuvaaja paikalla</name>
+    </genre>
+  </contentMeta>
+  <assert qcode="sttlocmeta:default:7576">
+    <broader type="cpnat:geoArea" qcode="sttcity:392">
+      <name>Tallinna</name>
+    </broader>
+    <broader type="cpnat:geoArea" qcode="sttstate:67">
+      <name>N/A</name>
+    </broader>
+    <broader type="cpnat:geoArea" qcode="sttcountry:238">
+      <name>Viro</name>
+    </broader>
+    <broader type="cpnat:geoArea" qcode="wldreg:150">
+      <name>Eurooppa</name>
+    </broader>
+  </assert>
+  <assert qcode="sttlocmeta:default:8975">
+    <broader type="cpnat:geoArea" qcode="sttcountry:1">
+      <name>Suomi</name>
+    </broader>
+    <broader type="cpnat:geoArea" qcode="wldreg:150">
+      <name>Eurooppa</name>
+    </broader>
+  </assert>
+  <assert qcode="sttlocmeta:rich:20016">
+        <name>Myanmar</name>
+        <definition />
+        <geoAreaDetails />
+        <POIDetails>
+            <address>
+                <line> </line>
+                <postalCode />
+            </address>
+        </POIDetails>
+        <broader type="cpnat:geoArea" qcode="wldreg:142">
+            <name>Aasia</name>
+        </broader>
+  </assert>
+  <contentSet>
+    <inlineXML contenttype="xhtml/xml">
+      <html>
+        <body>
+          <p>This is a test article for STT source mapping.</p>
+          <p>It includes content from STT and AFP sources.</p>
+          <p>Minister Soini is visiting the US for discussions.</p>
+        </body>
+      </html>
+    </inlineXML>
+  </contentSet>
+</newsItem>

--- a/server/tests/stt_newsroom_ninjs_formatter_test.py
+++ b/server/tests/stt_newsroom_ninjs_formatter_test.py
@@ -1,6 +1,7 @@
 from tests import TestCase
 from stt.stt_newsroom_ninjs_formatter import STTNewsroomNinjsFormatter
 
+
 class STTNewsroomNinjsFormatterTest(TestCase):
     fixture = "stt_newsml_creditline_test.xml"
     add_stt_cvs = True
@@ -10,7 +11,7 @@ class STTNewsroomNinjsFormatterTest(TestCase):
         subscriber = {
             "_id": "test_subscriber",
             "name": "Test Subscriber",
-            "destinations": [{"format": "stt newsroom ninjs"}]
+            "destinations": [{"format": "stt newsroom ninjs"}],
         }
         formatter = STTNewsroomNinjsFormatter()
         ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
@@ -18,11 +19,11 @@ class STTNewsroomNinjsFormatterTest(TestCase):
 
     async def test_source_formatting_no_sources_fallback(self):
         await self.parse_source_content()
-        self.item["subject"] = []  
+        self.item["subject"] = []
         subscriber = {
             "_id": "test_subscriber",
             "name": "Test Subscriber",
-            "destinations": [{"format": "stt newsroom ninjs"}]
+            "destinations": [{"format": "stt newsroom ninjs"}],
         }
         formatter = STTNewsroomNinjsFormatter()
         ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
@@ -38,9 +39,8 @@ class STTNewsroomNinjsFormatterTest(TestCase):
         subscriber = {
             "_id": "test_subscriber",
             "name": "Test Subscriber",
-            "destinations": [{"format": "stt newsroom ninjs"}]
+            "destinations": [{"format": "stt newsroom ninjs"}],
         }
         formatter = STTNewsroomNinjsFormatter()
         ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
         self.assertEqual(ninjs["source"], "STT, AFP")
-

--- a/server/tests/stt_newsroom_ninjs_formatter_test.py
+++ b/server/tests/stt_newsroom_ninjs_formatter_test.py
@@ -1,0 +1,46 @@
+from tests import TestCase
+from stt.stt_newsroom_ninjs_formatter import STTNewsroomNinjsFormatter
+
+class STTNewsroomNinjsFormatterTest(TestCase):
+    fixture = "stt_newsml_creditline_test.xml"
+    add_stt_cvs = True
+
+    async def test_source_formatting(self):
+        await self.parse_source_content()
+        subscriber = {
+            "_id": "test_subscriber",
+            "name": "Test Subscriber",
+            "destinations": [{"format": "stt newsroom ninjs"}]
+        }
+        formatter = STTNewsroomNinjsFormatter()
+        ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
+        self.assertEqual(ninjs["source"], "STT, AFP")
+
+    async def test_source_formatting_no_sources_fallback(self):
+        await self.parse_source_content()
+        self.item["subject"] = []  
+        subscriber = {
+            "_id": "test_subscriber",
+            "name": "Test Subscriber",
+            "destinations": [{"format": "stt newsroom ninjs"}]
+        }
+        formatter = STTNewsroomNinjsFormatter()
+        ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
+        self.assertEqual(ninjs["source"], "STT")
+
+    async def test_source_formatting_duplicates_handling(self):
+        # ensure duplicates are removed and STT always stays first
+        self.item["subject"] = [
+            {"name": "STT", "scheme": "sttsource"},
+            {"name": "AFP", "scheme": "sttsource"},
+            {"name": "AFP", "scheme": "sttsource"},
+        ]
+        subscriber = {
+            "_id": "test_subscriber",
+            "name": "Test Subscriber",
+            "destinations": [{"format": "stt newsroom ninjs"}]
+        }
+        formatter = STTNewsroomNinjsFormatter()
+        ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
+        self.assertEqual(ninjs["source"], "STT, AFP")
+


### PR DESCRIPTION
# Purpose
Map the STT sources (sttsource CV items) to the newsroom NinJS output’s source field

# What has changed
• Added custom STTNewsroomNinjsFormatter with to parse and format `ninjs.source` from sttsource subjects with STT being first and then the rest in alphabetical order.
• Added tests and a new fixture file for the new formatter covering multi-source, single-source, and fallback scenarios