### PR TITLE
Fix vocabulary config in assignments list

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12638,8 +12638,7 @@
         },
         "node_modules/superdesk-planning": {
             "version": "3.0.0-dev.0",
-            "resolved": "git+ssh://git@github.com/superdesk/superdesk-planning.git#588e38ce2f658170d16f781c80662445c8efcfbb",
-            "integrity": "sha512-H6HQ0fJcG0MO3EvJtUzzPQU2EUp6uCLi3n2lyiXCBHvPCswlb3Z8xx6HXNEv/AkTcIkbUYsY2yEX0e0trTToyg==",
+            "resolved": "git+ssh://git@github.com/superdesk/superdesk-planning.git#40e9bb0e1cf313c7d92159a20d2371a6a3c3764b",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@sourcefabric/common": "0.0.69",

--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -287,7 +287,7 @@ module.exports = function (grunt) {
           {fieldId: 'desk'},
           {fieldId: 'genre'},
           {fieldId: 'language'},
-          //{fieldId: 'vocabulary', vocabularyId: 'sttsource'},
+          {fieldId: 'vocabulary', fieldOptions: {vocabularyId: 'sttsource'}},
           {fieldId: 'anpa_category'},
         ],
       },


### PR DESCRIPTION
STT-1242

I've fixed the config format, but vocabulary fields still won't work, because `subject` field doesn't come from `coverage` to `assignment` (`assignment.planning.subject`). Could you fix this @petrjasek?