### PR TITLE
Feat/lupaus planning stturgency

### DIFF
--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -160,6 +160,73 @@ def _find_many(
         return []
 
 
+def get_stturgency_from_agenda_item(item: Dict[str, Any]) -> str:
+    """
+    Extracts the 'stturgency' value from an agenda item.
+
+    The function looks for the 'stturgency' in the 'subject' field of the item,
+    which is expected to be a list of dictionaries. Each dictionary may contain
+    a 'scheme' key. If a dictionary with 'scheme' equal to 'stturgency' is found,
+    the corresponding 'name' value is returned.
+
+    If 'stturgency' is not found, an empty string is returned.
+
+    Args:
+        item: A dictionary representing an agenda item.
+    Returns:
+        The value of 'stturgency' if found, otherwise an empty string.
+    """
+    # stturgency is stored in subject like:
+    # subject: [{'scheme': 'stturgency', 'name': 'Pääaihe (3 300)', 'qcode': 'stturgency-1'}]
+    if not item:
+        return ""
+    if "subject" in item:
+        for sub in item["subject"]:
+            if sub.get("scheme") == "stturgency":
+                return sub.get("name", "")
+    return ""
+
+
+def get_numeric_value_from_stturgency(stturgency: str) -> str:
+    """
+    Extracts the numeric value from a stturgency string.
+
+    The function assumes that the stturgency string is formatted as
+    'Some text (number)', where 'number' is the numeric
+    value to be extracted. It looks for the last pair of parentheses
+    in the string and extracts the content within them. If the content
+    can be converted to an integer, it is returned (as a string). If not, or if the
+    expected format is not found, the function returns an empty string.
+
+    There's one exception: "Vain tulokset" and in that case we return "Vain tulokset"
+
+    Args:
+        stturgency: A string representing the stturgency.
+    Returns:
+        The numeric value extracted from the stturgency string, or an empty string if not found or not convertible.
+    """
+    if not stturgency:
+        return ""
+    if stturgency == "Vain tulokset":
+        return stturgency
+    try:
+        # Find the last '(' and ')' and extract the content between them
+        start = stturgency.rindex("(") + 1
+        end = stturgency.rindex(")")
+        number_str = stturgency[start:end].strip()
+        return str(number_str.replace(" ", ""))
+    except (ValueError, IndexError):
+        return ""
+
+
+def _set_stt_urgency_fields(pl: Dict[str, Any]) -> None:
+    """Compute and set urgency fields on a planning item in a single place."""
+    urgency = get_stturgency_from_agenda_item(pl)
+    urgency_numeric = get_numeric_value_from_stturgency(urgency)
+    pl["stturgency"] = urgency
+    pl["stturgency_numeric"] = urgency_numeric
+
+
 def enrich_planning_agendas(agendas: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Adds item.related_events_expanded = [event, ...]
@@ -188,6 +255,7 @@ def enrich_planning_agendas(agendas: List[Dict[str, Any]]) -> List[Dict[str, Any
         # No matches → leave empty but return agendas intact
         for ag in agendas or []:
             for pl in ag.get("items") or []:
+                _set_stt_urgency_fields(pl)
                 pl["related_events_expanded"] = []
         return agendas
 
@@ -199,12 +267,24 @@ def enrich_planning_agendas(agendas: List[Dict[str, Any]]) -> List[Dict[str, Any
     # Attach to each planning item
     for ag in agendas or []:
         for pl in ag.get("items") or []:
+            # compute urgency once per item
+            _set_stt_urgency_fields(pl)
             expanded: List[Dict[str, Any]] = []
+
             for re in pl.get("related_events") or []:
                 key = re.get("_id")
                 ev = by_key.get(str(key)) if key else None
                 if ev:
                     expanded.append(ev)
             pl["related_events_expanded"] = expanded
+
+    # Sort related_events_expanded by start date
+    for ag in agendas or []:
+        for pl in ag.get("items") or []:
+            pl["related_events_expanded"].sort(
+                key=lambda e: e.get("dates", {}).get("start")
+                or e.get("dates", {}).get("end")
+                or ""
+            )
 
     return agendas

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -216,6 +216,9 @@ def get_numeric_value_from_stturgency(stturgency: str) -> str:
         number_str = stturgency[start:end].strip()
         return str(number_str.replace(" ", ""))
     except (ValueError, IndexError):
+        logger.debug(
+            "Could not extract numeric value from stturgency: '%s'", stturgency
+        )
         return ""
 
 

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -254,9 +254,14 @@ def enrich_planning_agendas(agendas: List[Dict[str, Any]]) -> List[Dict[str, Any
     if not events:
         # No matches → leave empty but return agendas intact
         for ag in agendas or []:
+            new_items: List[Dict[str, Any]] = []
             for pl in ag.get("items") or []:
                 _set_stt_urgency_fields(pl)
+                if not pl.get("stturgency"):
+                    continue  # exclude items without stturgency
                 pl["related_events_expanded"] = []
+                new_items.append(pl)
+            ag["items"] = new_items
         return agendas
 
     # Map by both _id and guid for resilience
@@ -266,9 +271,12 @@ def enrich_planning_agendas(agendas: List[Dict[str, Any]]) -> List[Dict[str, Any
             by_key[str(e["_id"])] = e
     # Attach to each planning item
     for ag in agendas or []:
+        expanded_items: List[Dict[str, Any]] = []
         for pl in ag.get("items") or []:
             # compute urgency once per item
             _set_stt_urgency_fields(pl)
+            if not pl.get("stturgency"):
+                continue  # exclude items without stturgency
             expanded: List[Dict[str, Any]] = []
 
             for re in pl.get("related_events") or []:
@@ -277,6 +285,8 @@ def enrich_planning_agendas(agendas: List[Dict[str, Any]]) -> List[Dict[str, Any
                 if ev:
                     expanded.append(ev)
             pl["related_events_expanded"] = expanded
+            expanded_items.append(pl)
+        ag["items"] = expanded_items
 
     # Sort related_events_expanded by start date
     for ag in agendas or []:

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -12,6 +12,19 @@
     {%- endif -%}
 {%- endmacro %}
 
+{# macro to render STT urgency text #}
+{% macro stt_urgency_text(item) -%}
+  {%- set has_str = (item.stturgency is defined) and (item.stturgency | trim) -%}
+  {%- set has_num = (item.stturgency_numeric is defined) and (item.stturgency_numeric is not none) -%}
+  {%- if not has_str or not has_num -%}
+    {# empty output when not set #}
+  {%- elif item.stturgency == 'Vain tulokset' -%}
+    {{- item.stturgency -}}
+  {%- else -%}
+    Mittaversio korkeintaan {{ item.stturgency_numeric }} merkkiä.
+  {%- endif -%}
+{%- endmacro %}
+
 {# One paragraph per agenda item #}
 {%- for agenda in agendas or [] -%}
     {%- for item in agenda['items'] | default([]) -%}
@@ -19,13 +32,16 @@
         {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
         {%- if item.description_text %}{% set _ = bits.append(item.description_text) %}{% endif -%}
         {%- for ev in item.related_events_expanded or [] -%}
-        {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
-        {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
-        {%- if ev.location is iterable -%}
-            {%- set ev_loc = lupaus_location(ev.location) -%}
-            {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
-        {%- endif -%}
+            {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
+            {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
+            {%- if ev.location is iterable -%}
+                {%- set ev_loc = lupaus_location(ev.location) -%}
+                {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
+            {%- endif -%}
         {%- endfor -%}
+        {# Call the urgency macro #}
+        {%- set urg = stt_urgency_text(item) -%}
+        {%- if urg %}{% set _ = bits.append(urg) %}{% endif -%}
         {%- if bits %}<p>{{- bits | join(', ') -}}</p>{% endif -%}
         {# add empty line between items #}
         <p></p>

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -21,7 +21,7 @@
   {%- elif item.stturgency == 'Vain tulokset' -%}
     {{- item.stturgency -}}
   {%- else -%}
-    Mittaversio korkeintaan {{ item.stturgency_numeric }} merkkiä.
+    Mittaversio korkeintaan {{ item.stturgency_numeric }} merkkiä
   {%- endif -%}
 {%- endmacro %}
 
@@ -42,7 +42,14 @@
         {# Call the urgency macro #}
         {%- set urg = stt_urgency_text(item) -%}
         {%- if urg %}{% set _ = bits.append(urg) %}{% endif -%}
-        {%- if bits %}<p>{{- bits | join(', ') -}}</p>{% endif -%}
+        {# Add coverages if available #}
+        {%- if item.coverages is defined and item.coverages -%}
+        {%- set cov_list = item.coverages if item.coverages is iterable else [item.coverages] -%}
+        {%- if cov_list | length > 0 -%}
+            {%- set _ = bits.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
+        {%- endif -%}
+        {%- endif -%}
+        {%- if bits %}<p>{{- bits | join(', ') -}}.</p>{% endif -%}
         {# add empty line between items #}
         <p></p>
     {%- endfor -%}


### PR DESCRIPTION
1b: Planning info with priority

Slugline. Description. Event name (if not the same as the planning item name), klo event start time, event location name. Mittaversio korkeintaan xxx merkkiä.* 

That character mark needed is told in aiheen tärkeys / urgency after each value. E. g. Pääaihe (3 300).

Not! If urgency value “vain tulokset” instead of “mittaversio xxx merkkiä”, “Vain tulokset” should be displayed.

Note! Planning items without any value in aiheen tärkeys need to be excluded even if the user has selected them for the report .

