### PR TITLE
Fix PLANNING_AUTO_ASSIGN_TO_WORKFLOW config

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -245,7 +245,7 @@ PLANNING_EVENT_TEMPLATES_ENABLED = env("PLANNING_EVENT_TEMPLATES_ENABLED", "true
 ENABLE_FULFILL_ASSIGNMENTS = env("ENABLE_FULFILL_ASSIGNMENTS", "true")
 
 # automatically add coverage assignments to workflow
-PLANNING_AUTO_ASSIGN_TO_WORKFLOW = env("PLANNING_AUTO_ASSIGN_TO_WORKFLOW", "true")
+PLANNING_AUTO_ASSIGN_TO_WORKFLOW = env("PLANNING_AUTO_ASSIGN_TO_WORKFLOW", True)
 
 # check for unfulfilled assignments when publishing a story (based on slugline)
 PLANNING_CHECK_FOR_ASSIGNMENT_ON_PUBLISH = env(


### PR DESCRIPTION
SDESK-7772

@petrjasek looks like the config had a bunch of changes and strings were used in places where we need to have a boolean. Let me know if I should change the rest. I think this was the PR that changed it - https://github.com/superdesk/superdesk-stt/pull/201

Might be that all of these: `PLANNING_EVENT_TEMPLATES_ENABLED`, `ENABLE_FULFILL_ASSIGNMENTS`, `PLANNING_CHECK_FOR_ASSIGNMENT_ON_SEND`, `PLANNING_USE_XMP_FOR_PIC_ASSIGNMENTS`, `PLANNING_USE_XMP_FOR_PIC_SLUGLINE`, `ANALYTICS_ENABLE_SCHEDULED_REPORTS`, `ANALYTICS_ENABLE_ARCHIVE_STATS`, work by accident since the fallback values look wrong to me 