### PR TITLE
feat(merkkipaiva): add export template, filters, and app wiring

### DIFF
--- a/server/data/planning_export_templates.json
+++ b/server/data/planning_export_templates.json
@@ -30,5 +30,15 @@
       "headline_template": "kuvalupaus_events_headline.html"
     },
     "label": "Kuvalupaus Template"
+  },
+  {
+    "_id": "merkkipaiva_list",
+    "init_version": 1,
+    "name": "merkkipaiva_list",
+    "type": "planning",
+    "data": {
+      "body_html_template": "merkkipaiva_template.html"
+    },
+    "label": "Merkkipäivä Template"
   }
 ]

--- a/server/settings.py
+++ b/server/settings.py
@@ -142,6 +142,7 @@ INSTALLED_APPS = [
     "stt.template_filters",
     "stt.paivalista_export",
     "stt.lupaus_export",
+    "stt.merkkipaiva_export",
     "stt.paivalista_filters",
     "stt.stt_tt_new_parse_ninjs",
     "stt.io.feed_parsers.stt_events_csv_parse",

--- a/server/stt/merkkipaiva_export/__init__.py
+++ b/server/stt/merkkipaiva_export/__init__.py
@@ -1,0 +1,6 @@
+def init_app(app):
+    from .common import format_merkkipaiva_for_export
+
+    app.jinja_env.globals.update(
+        format_merkkipaiva_for_export=format_merkkipaiva_for_export
+    )

--- a/server/stt/merkkipaiva_export/common.py
+++ b/server/stt/merkkipaiva_export/common.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class Formatted:
+    rows: List[Dict[str, Any]]
+
+
+def format_merkkipaiva_for_export(items):
+    rows = items or []
+    # TODO: sorting etc. if needed
+
+    return {"rows": rows}

--- a/server/stt/template_filters/__init__.py
+++ b/server/stt/template_filters/__init__.py
@@ -62,8 +62,17 @@ def fi_ddmm(value: str) -> str:
     return f"{dt.day:02d}.{dt.month:02d}."
 
 
+def fi_which_weekday(value: str) -> str:
+    # "2025-10-14T00:00:00+0000" => "tiistaina 14.10."
+    dt = _to_helsinki(value)
+    if not dt:
+        return ""
+    return f"{_WEEKDAY_FI[dt.weekday()]}na {dt.day}.{dt.month}."
+
+
 def init_app(app):
     app.jinja_env.filters["fi_date"] = fi_date
     app.jinja_env.filters["fi_time"] = fi_time
     app.jinja_env.filters["fi_ddmm"] = fi_ddmm
     app.jinja_env.globals["fi_current_date"] = fi_current_date
+    app.jinja_env.filters["fi_which_weekday"] = fi_which_weekday

--- a/server/templates/merkkipaiva_template.html
+++ b/server/templates/merkkipaiva_template.html
@@ -1,0 +1,32 @@
+{# ---------------------------------------- #
+   merkkipaiva_template.html
+# ---------------------------------------- #}
+
+{% set formatted = format_merkkipaiva_for_export(items) %}
+
+{#-- Always default header text --#}
+<p>STT:n erillismaksullisessa merkkipäiväpalvelussa tällä viikolla:</p>
+{#-- MAIN LOOP --#}
+{% for item in formatted.rows %}
+    {# Collect all parts to a list and join at the end #}
+    {% set parts = [] %}
+    {# slugline ----------- #}
+    {% if item.slugline %}
+        {% set _ = parts.append(item.slugline) %}
+    {% endif %}
+
+    {# Planning date ------------------------- #}
+    {% if item.planning_date %}
+        {% set _ = parts.append("Juttu tulee " ~ (item.planning_date | fi_which_weekday)) %}
+    {% endif %}
+    {%- if parts %}<p>- {{- parts | join(' ') -}}</p>{% endif -%}
+    <p></p>   {# blank line at the end #}
+{% endfor %}
+
+{#-- Always default footer text --#}
+<p>Voitte katsoa tekstejä ja poimia ne helposti myös STT:n Mediapankista tunnuksella merkkipaivat@stt.fi ja salasanalla Merkkarit2025. Kuviin voimme toimittaa sähköpostilinkin.</p>
+<p>Juttupakettiin kuuluu vähintään runsaan 3 000 merkin haastattelu, noin 800 merkin CV-faktalaatikko ja viisi kuvaa Lehtikuvalta. Voitte ostaa haastattelun merkkipäiväpalvelun tuottajalta.</p>
+<p>tuottaja Tommi Peltoniemi</p>
+<p>09 69581 426</p>
+<p>050 598 4675</p>
+<p><a href="mailto:merkkipaivat@stt.fi">merkkipaivat@stt.fi</a></p>


### PR DESCRIPTION
- register merkkipaiva_list in planning_export_templates.json
- enable stt.merkkipaiva_export in settings
- add merkkipaiva_export package with formatter helper (globals)
- expose new fi_which_weekday filter for date wording
- create merkkipaiva_template.html body template