### PR TITLE
Refine Lupaus export coverage lookup and template filtering

### DIFF
--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -37,10 +37,10 @@ def _collect_event_ids(agendas: List[Dict[str, Any]]) -> List[str]:
     ids: Set[str] = set()
     for ag in agendas or []:
         for pl in ag.get("items") or []:
-            for re in pl.get("related_events") or []:
+            for rel_event in pl.get("related_events") or []:
                 # tolerate various shapes
                 for key in ("_id", "event", "event_id", "guid"):
-                    val = re.get(key)
+                    val = rel_event.get(key)
                     if val:
                         ids.add(str(val))
                         break
@@ -51,9 +51,9 @@ def _get_planning_item_coverage_status_from_mongo(
     pl: Dict[str, Any], item_type: str
 ) -> Dict[str, Any]:
     """
-    For some reason item.coverages is like coverages': ['Kuvauskeikka', 'Teksti']
+    For some reason item.coverages might be like coverages': ['Kuvauskeikka', 'Kuvitus', 'Uutisteksti']
     but we need "planning.coverages.news_coverage_status"-data from mongo by item _id
-    Get the 'news_coverage_status' from the 'coverages' of a planning item.
+    Get the 'news_coverage_status' from the 'coverages' of a planning item if it does not exist in the item.
     Args:
         pl: A dictionary representing a planning item.
         item_type: The type of the planning item, e.g., 'teksti' / 'kuva'.
@@ -65,6 +65,10 @@ def _get_planning_item_coverage_status_from_mongo(
     # skip if no coverages
     if "coverages" not in pl or not pl["coverages"]:
         return {}
+    # Check if item already has news_coverage_status
+    for cov in pl["coverages"]:
+        if "news_coverage_status" in cov and cov["news_coverage_status"]:
+            return cov["news_coverage_status"]
     pl_id = pl.get("_id")
     # skip if no id for some reason
     if not pl_id:
@@ -73,20 +77,18 @@ def _get_planning_item_coverage_status_from_mongo(
     if item_type == "kuva":
         pl_from_mongo = find_many(
             "planning",
-            # get only coverages that have "planning.g2_content_type" = "kuvauskeikka" or "kuvitus"
+            # get only coverages that have "planning.g2_content_type" = "graphic"
             {
                 "_id": pl_id,
-                "coverages.planning.g2_content_type": {
-                    "$in": ["kuvauskeikka", "kuvitus"]
-                },
+                "coverages.planning.g2_content_type": "graphic",
             },
             projection={"coverages": 1, "_id": 0},
         )
     else:
         pl_from_mongo = find_many(
             "planning",
-            # get only coverages that have "planning.g2_content_type" = "teksti"
-            {"_id": pl_id, "coverages.planning.g2_content_type": "teksti"},
+            # get only coverages that have "planning.g2_content_type" = "text"
+            {"_id": pl_id, "coverages.planning.g2_content_type": "text"},
             projection={"coverages": 1, "_id": 0},
         )
     if not pl_from_mongo:
@@ -109,6 +111,8 @@ def get_priority_from_agenda_item(item: Dict[str, Any]) -> str:
     a 'scheme' key. If a dictionary with 'scheme' equal to 'priority' is found,
     the corresponding 'name' value is returned.
 
+    Or it looks in 'priority' field as a numeric value and maps it to a string.
+
     If 'priority' is not found, an empty string is returned.
 
     Args:
@@ -124,17 +128,33 @@ def get_priority_from_agenda_item(item: Dict[str, Any]) -> str:
         for sub in item["subject"]:
             if sub.get("scheme") == "priority":
                 return sub.get("name", "")
+    if "priority" in item:
+        numeric_priority = item.get("priority", "")
+        # if numeric_priority is > 0, return customized priority with synthetic 'name'-field
+        if numeric_priority and numeric_priority > 0:
+            # 1 = Pääaihe (3300), 2 = Perus (2000), 3 = Perus+ (2700), 4 = Lyhyt (800), 5 = Vain tulokset
+            priority_map = {
+                1: "Pääaihe (3 300)",
+                2: "Perus (2 000)",
+                3: "Perus+ (2 700)",
+                4: "Lyhyt (800)",
+                5: "Vain tulokset",
+            }
+            return priority_map.get(numeric_priority, "")
+
     return ""
 
 
 def get_category_from_agenda_item(item: Dict[str, Any]) -> str:
     """
-    Extracts the "scheme": "categories" value from an agenda item subjects.
+    Extracts the "scheme": "categories" value from an agenda item subjects or anpa_category.
 
     The function looks for the 'categories' in the 'subject' field of the item,
     which is expected to be a list of dictionaries. Each dictionary may containa 'scheme' key. If a dictionary with 'scheme' equal to 'categories' is found,
     a 'scheme' key. If a dictionary with 'scheme' equal to 'categories' is found,
     the corresponding 'name' value is returned.
+
+    Or it looks in 'anpa_category' field.
 
     If 'categories' is not found, an empty string is returned.
 
@@ -145,11 +165,17 @@ def get_category_from_agenda_item(item: Dict[str, Any]) -> str:
     """
     # categories is stored in subject like:
     # subject: [{'scheme': 'categories', 'name': 'Kulttuuri', 'qcode': '4'}]
+    # or in anpa_category like:
+    # 'anpa_category': [{'name': 'Kulttuuri', 'qcode': '4'}]
     if not item:
         return ""
     if "subject" in item:
         for sub in item["subject"]:
             if sub.get("scheme") == "categories":
+                return sub.get("name", "")
+    if "anpa_category" in item:
+        for sub in item["anpa_category"]:
+            if sub:
                 return sub.get("name", "")
     return ""
 
@@ -228,8 +254,8 @@ def _set_stt_fields(
                 continue
             # Expand related events
             expanded: List[Dict[str, Any]] = []
-            for re in pl.get("related_events") or []:
-                key = re.get("_id")
+            for rel_event in pl.get("related_events") or []:
+                key = rel_event.get("_id")
                 ev = by_key.get(str(key)) if key else None
                 if ev:
                     expanded.append(ev)
@@ -318,7 +344,7 @@ def enrich_planning_agendas(
             "name": 1,
             "dates": 1,
             "location": 1,
-            "language": 1,
+            "subject": 1,
         },
     )
     if not events:

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -40,11 +40,20 @@
   {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
   {%- if item.description_text %}{% set _ = bits.append(item.description_text) %}{% endif -%}
   {%- for ev in item.related_events_expanded or [] -%}
-    {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
-    {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
-    {%- if ev.location is iterable -%}
-      {%- set ev_loc = lupaus_location(ev.location) -%}
-      {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
+    {%- set ev_subjects = ev.subject | default([]) -%}
+    {%- set is_competition = ev_subjects
+      | selectattr('scheme', 'equalto', 'event_type')
+      | selectattr('name', 'equalto', 'Kilpailut')
+      | list
+      | length > 0 -%}
+      {# Do not include event details if it is a competition #}
+    {%- if not is_competition -%}
+      {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
+      {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
+      {%- if ev.location is iterable -%}
+        {%- set ev_loc = lupaus_location(ev.location) -%}
+        {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
+      {%- endif -%}
     {%- endif -%}
   {%- endfor -%}
   {# Call the priority macro #}
@@ -71,6 +80,18 @@
   <p></p>
 {%- endmacro %}
 
+{# Actual rendering logic for the agenda items starts here #}
+
+{# ---------------------------------------- #}
+{#   HEADER TEXT FOR ALL REPORTS            #}
+{# ---------------------------------------- #}
+<p>Valmistumisajoista: Huomaattehan, että STT lähettää verkkokäyttöön sopivia, päivittyviä versioita päivän aiheista aina mahdollisimman pian uutistapahtuman käynnistyttyä. Listassa mainitut valmistumiskellonajat tarkoittavat myöhäisempää uutisversiota, joka sopii mm. printtikäyttöön. Osaan listan aiheista on merkitty myös pikaplus-version eli ensimmäisen pidemmän verkkoversion arvioitu valmistumisaika.</p>
+
+<p>Selitykset listassa yleisimmin käytettyihin STT:n uutisversioiden nimiin löytyvät listan lopusta.</p>
+<br />
+{# ---------------------------------------- #}
+{#   MAIN TEMPLATE BODY                    #}
+{# ---------------------------------------- #}
 {# One paragraph per agenda item; grouped by category if grouped_items present #}
 {%- for agenda in agendas or [] -%}
   {%- set main_topic_items = agenda.get('main_topic_items') -%}
@@ -118,4 +139,26 @@
     {%- endfor -%}
   {%- endif -%}
 {%- endfor -%}
+<br />
+{# ---------------------------------------- #}
+{#   FOOTER TEXT FOR ALL REPORTS            #}
+{# ---------------------------------------- #}
 
+<p>Aamupika = Aamuyöstä/varhaisaamusta julkaistava lyhyt, ennakoiva uutisversio. Verkko- ja radiomuoto.</p>
+<p>Pika+ = Ensisijassa verkkokäyttöön tarkoitettu uutisversio.</p>
+<p>Mittaversio = Mittaan kirjoitettu uutisversio, jonka muotoilut sopivat printille. Versiotyyppinä pika+, joten sopii myös verkkokäyttöön.</p>
+<p>Ystävällisin terveisin,<br />
+Uutispäälliköt<br />
+Klo 6.30-14 Merja Könönen<br />
+Klo 13.30-21 Tapio Pellinen<br />
+p. 09 - 695 81 327<br />
+uutispaallikot@stt.fi
+</p>
+<p>Kuvatoimitus<br />
+p. 09 - 695 81 250<br />
+uutiskuva@stt.fi<br />
+</p>
+<p>Urheilutoimitus<br />
+p. 09-69581263<br />
+sport@stt.fi<br />
+</p>


### PR DESCRIPTION
- ensure Mongo g2_content_type lookups use text/graphic values and return existing coverage status immediately
- derive priority/category from numeric or anpa fields when subject metadata is absent
- ignore competition-type related events when rendering Lupaus planning items
- add default header / footer text for Lupaus planning template