### PR TITLE
[STT-1388] - Changed sttsource output format to use dash separator

### DIFF
--- a/server/stt/stt_newsroom_ninjs_formatter.py
+++ b/server/stt/stt_newsroom_ninjs_formatter.py
@@ -34,7 +34,7 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
             else:
                 sorted_sources = sorted(unique_sources, key=str.lower)
 
-            ninjs["source"] = ", ".join(sorted_sources)
+            ninjs["source"] = "-".join(sorted_sources)
         except Exception as e:
             logger.error(f"Error occurred when updating ninjs stt sources: {str(e)}")
 

--- a/server/tests/stt_newsroom_ninjs_formatter_test.py
+++ b/server/tests/stt_newsroom_ninjs_formatter_test.py
@@ -15,7 +15,7 @@ class STTNewsroomNinjsFormatterTest(TestCase):
         }
         formatter = STTNewsroomNinjsFormatter()
         ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
-        self.assertEqual(ninjs["source"], "STT, AFP")
+        self.assertEqual(ninjs["source"], "STT-AFP")
 
     async def test_source_formatting_no_sources_fallback(self):
         await self.parse_source_content()
@@ -43,4 +43,4 @@ class STTNewsroomNinjsFormatterTest(TestCase):
         }
         formatter = STTNewsroomNinjsFormatter()
         ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
-        self.assertEqual(ninjs["source"], "STT, AFP")
+        self.assertEqual(ninjs["source"], "STT-AFP")


### PR DESCRIPTION
## Purpose
This PR changes the sttsource output from comma to dash. Hence, instead of "STT, AFP", we have "STT-AFP" sent to Newshub.

Issue : [STT-1388](https://sofab.atlassian.net/browse/STT-1388)

[STT-1388]: https://sofab.atlassian.net/browse/STT-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ