### PR TITLE
[STT-1422] - Adjust JSON output format for Newshub

### DIFF
--- a/server/stt/stt_json_planning_formatter.py
+++ b/server/stt/stt_json_planning_formatter.py
@@ -6,6 +6,44 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
     name = "STT JSON Planning"
     type = "stt_json_planning"
 
+    CATEGORY_QCODE_NHUB_MAP = {
+        "3": {
+            "name": "Kotimaa",
+            "agenda_id": "673f47881562ef05527e195a",
+            "calendar_qcode": "kotimaa",
+        },
+        "4": {
+            "name": "Kulttuuri",
+            "agenda_id": "673f478f2c95fe4cab8ee67e4",
+            "calendar_qcode": "kulttuuri",
+        },
+        "9": {
+            "name": "Politiikka",
+            "agenda_id": "673f47a1f16a90a38481291f",
+            "calendar_qcode": "politiikka",
+        },
+        "11": {
+            "name": "Talous",
+            "agenda_id": "673f47a914ae7505c4ba6138",
+            "calendar_qcode": "talous",
+        },
+        "14": {
+            "name": "Ulkomaat",
+            "agenda_id": "673f47b114ae7505c4ba613a",
+            "calendar_qcode": "ulkomaat",
+        },
+        "16": {
+            "name": "Urheilu",
+            "agenda_id": "673f47ba1562ef05527e195c",
+            "calendar_qcode": "urheilu",
+        },
+        "not_sports": {
+            "name": "Muut kuin urheilu",
+            "agenda_id": "673f47982c95fe4cab8ee67e",
+            "calendar_qcode": "muutkuinurheilu",
+        },
+    }
+
     def __init__(self):
         super().__init__()
         self.format_type = "stt_json_planning"
@@ -101,12 +139,29 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
         anpa_category = item.get("anpa_category", [])
         agendas = []
         for category in anpa_category:
-            agendas.append({"_id": category["name"], "name": category["name"]})
+            qcode = category.get("qcode")
+            if qcode in self.CATEGORY_QCODE_NHUB_MAP:
+                category_qcode_entry = self.CATEGORY_QCODE_NHUB_MAP[qcode]
+                agendas.append(
+                    {
+                        "_id": category_qcode_entry["agenda_id"],
+                        "name": category_qcode_entry["name"],
+                    }
+                )
+            else:
+                name = category.get("name", "")
+                sanitized = name.lower().replace(" ", "")
+                agendas.append({"_id": sanitized, "name": name})
 
-        # Special case to inclide "Muut kuin urheilu" if there are non-sport categories
-        has_non_sport = any(category["name"] != "Urheilu" for category in anpa_category)
+        has_non_sport = any(
+            category.get("name") != "Urheilu" for category in anpa_category
+        )
         if has_non_sport:
-            agendas.append({"_id": "Muut kuin urheilu", "name": "Muut kuin urheilu"})
+            not_sports = self.CATEGORY_QCODE_NHUB_MAP.get("not_sports")
+            if not_sports:
+                agendas.append(
+                    {"_id": not_sports["agenda_id"], "name": not_sports["name"]}
+                )
         item["agendas"] = agendas
 
     async def _format_item(self, item, subscribers: list[dict] | None = None):

--- a/server/stt/stt_json_planning_formatter.py
+++ b/server/stt/stt_json_planning_formatter.py
@@ -49,10 +49,13 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
             del item["internal_note"]
         if "subject" in item:
             item["subject"] = [
-                subj for subj in item["subject"] if subj.get("scheme") != "sttcheckedby"
+                subject for subject in item["subject"] if subject.get("scheme") != "sttcheckedby"
             ]
 
     def exclude_internal_coverage_fields(self, item):
+        if not item.get("coverages"):
+            return
+
         exclude_fields = [
             "headline",
             "location",
@@ -74,21 +77,23 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
             "sttpictureinvoiced",
         ]
 
-        if "coverages" in item:
-            for coverage in item["coverages"]:
-                if "planning" in coverage:
-                    planning = coverage["planning"]
-                    # First remove direct attributes in the planning obj
-                    for field in exclude_fields:
-                        if field in planning:
-                            del planning[field]
-                    # Then filter out internal fields from the fields array
-                    if "fields" in planning:
-                        planning["fields"] = [
-                            f
-                            for f in planning["fields"]
-                            if f.get("field") not in exclude_fields
-                        ]
+        for coverage in item["coverages"]:
+            planning = coverage.get("planning")
+            if not planning:
+                continue
+
+            # First remove direct attributes in the planning obj
+            for field in exclude_fields:
+                if field in planning:
+                    del planning[field]
+
+            # Then filter out internal fields from the fields array
+            if "fields" in planning:
+                planning["fields"] = [
+                    field
+                    for field in planning["fields"]
+                    if field.get("field") not in exclude_fields
+                ]
 
     def map_agenda_output(self, item):
         anpa_category = item.get("anpa_category", [])

--- a/server/stt/stt_json_planning_formatter.py
+++ b/server/stt/stt_json_planning_formatter.py
@@ -44,8 +44,69 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
                 }
             )
 
+    def exclude_internal_planning_fields(self, item):
+        if "internal_note" in item:
+            del item["internal_note"]
+        if "subject" in item:
+            item["subject"] = [
+                subj for subj in item["subject"] if subj.get("scheme") != "sttcheckedby"
+            ]
+
+    def exclude_internal_coverage_fields(self, item):
+        exclude_fields = [
+            "headline",
+            "location",
+            "sttpicturewhatabout",
+            "sttpicturewhatisphotographed",
+            "internal_note",
+            "sttdoesphotographerknow",
+            "sttpictureregistrationok",
+            "sttregistrationinfo",
+            "sttpicturecategory",
+            "sttpictureheadlinefi",
+            "sttpicturecaptionfi",
+            "sttpictureinstructionsfi",
+            "sttpicturekeywordsfi",
+            "sttpictureheadlineen",
+            "sttpicturecaptionen",
+            "sttpictureinstructionsen",
+            "sttpicturekeywordsen",
+            "sttpictureinvoiced",
+        ]
+
+        if "coverages" in item:
+            for coverage in item["coverages"]:
+                if "planning" in coverage:
+                    planning = coverage["planning"]
+                    # First remove direct attributes in the planning obj
+                    for field in exclude_fields:
+                        if field in planning:
+                            del planning[field]
+                    # Then filter out internal fields from the fields array
+                    if "fields" in planning:
+                        planning["fields"] = [
+                            f
+                            for f in planning["fields"]
+                            if f.get("field") not in exclude_fields
+                        ]
+
+    def map_agenda_output(self, item):
+        anpa_category = item.get("anpa_category", [])
+        agendas = []
+        for category in anpa_category:
+            agendas.append({"_id": category["name"], "name": category["name"]})
+
+        # Special case to inclide "Muut kuin urheilu" if there are non-sport categories
+        has_non_sport = any(category["name"] != "Urheilu" for category in anpa_category)
+        if has_non_sport:
+            agendas.append({"_id": "Muut kuin urheilu", "name": "Muut kuin urheilu"})
+        item["agendas"] = agendas
+
     async def _format_item(self, item, subscribers: list[dict] | None = None):
         await super()._format_item(item)
         self.update_stt_urgency(item)
+        self.exclude_internal_planning_fields(item)
+        self.exclude_internal_coverage_fields(item)
+        self.map_agenda_output(item)
 
         return item

--- a/server/stt/stt_json_planning_formatter.py
+++ b/server/stt/stt_json_planning_formatter.py
@@ -49,7 +49,9 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
             del item["internal_note"]
         if "subject" in item:
             item["subject"] = [
-                subject for subject in item["subject"] if subject.get("scheme") != "sttcheckedby"
+                subject
+                for subject in item["subject"]
+                if subject.get("scheme") != "sttcheckedby"
             ]
 
     def exclude_internal_coverage_fields(self, item):

--- a/server/tests/fixtures/json/stt_json_planning_item.json
+++ b/server/tests/fixtures/json/stt_json_planning_item.json
@@ -1,0 +1,204 @@
+{
+  "_created": "2025-10-28T10:13:10+0000",
+  "_current_version": 1761646415259,
+  "_etag": "ffc01a2ef4fb0867b0d8541fb45a9809c5c57249",
+  "_id": "f2158efe-aaec-4e77-8ea3-5c9b53f218eb",
+  "_updated": "2025-10-28T10:13:35+0000",
+  "agendas": [],
+  "all_day": true,
+  "anpa_category": [
+    {
+      "name": "Julkishallinnon tiedotepalvelu",
+      "qcode": "2",
+      "scheme": null
+    }
+  ],
+  "coverages": [
+    {
+      "add_coverage_to_workflow": true,
+      "assigned_desk": {
+        "name": "Default Desk"
+      },
+      "assigned_user": {
+        "display_name": "admin",
+        "first_name": "",
+        "last_name": ""
+      },
+      "coverage_id": "6b6a31b8-4f63-49f4-99cf-20f7a3c4fb7e",
+      "coverage_provider": null,
+      "deliveries": [],
+      "firstcreated": "2025-10-28T10:13:10+0000",
+      "news_coverage_status": {
+        "label": "Tehdään",
+        "name": "coverage intended",
+        "qcode": "ncostat:int"
+      },
+      "original_coverage_id": "6b6a31b8-4f63-49f4-99cf-20f7a3c4fb7e",
+      "planning": {
+        "anpa_category": [
+          {
+            "name": "Julkishallinnon tiedotepalvelu",
+            "qcode": "2",
+            "scheme": null
+          }
+        ],
+        "fields": [
+          {
+            "field": "sttpicturewhatabout",
+            "value": "Test what about"
+          },
+          {
+            "field": "sttpicturewhatisphotographed",
+            "value": "Test what is photographed"
+          },
+          {
+            "field": "sttregistrationinfo",
+            "value": "Test registration info"
+          },
+          {
+            "field": "sttpictureheadlinefi",
+            "value": "Test headline FI"
+          },
+          {
+            "field": "sttpicturecaptionfi",
+            "value": "Test caption FI"
+          },
+          {
+            "field": "sttpictureinstructionsfi",
+            "value": "Test instructions FI"
+          },
+          {
+            "field": "sttpicturekeywordsfi",
+            "value": "Test keywords FI"
+          },
+          {
+            "field": "sttpictureheadlineen",
+            "value": "Test headline EN"
+          },
+          {
+            "field": "sttpicturecaptionen",
+            "value": "Test caption EN"
+          },
+          {
+            "field": "sttpictureinstructionsen",
+            "value": "Test instructions EN"
+          },
+          {
+            "field": "sttpicturekeywordsen",
+            "value": "Test keywords EN"
+          }
+        ],
+        "g2_content_type": "picture",
+        "genre": [],
+        "headline": "Test Headline",
+        "internal_note": "Test Internal Note",
+        "language": "fi",
+        "location": [
+          {
+            "address": {
+              "city": "Test City",
+              "country": "Test Country",
+              "line": [
+                "Test Address"
+              ]
+            },
+            "details": "Test Details",
+            "name": "Test Location",
+            "qcode": "test-qcode"
+          }
+        ],
+        "multiple_content": false,
+        "priority": 1,
+        "scheduled": "2025-10-28T11:00:00+0000",
+        "slugline": "Test Slugline",
+        "subject": [
+          {
+            "name": "Test Image Type",
+            "qcode": "test-imagetype",
+            "scheme": "sttimagetype"
+          },
+          {
+            "name": "Ei",
+            "qcode": "no",
+            "scheme": "sttdoesphotographerknow"
+          },
+          {
+            "name": "Kyllä",
+            "qcode": "yes",
+            "scheme": "sttpictureregistrationok"
+          },
+          {
+            "name": "Test Category",
+            "qcode": "TEST",
+            "scheme": "sttpicturecategory"
+          },
+          {
+            "name": "Ei",
+            "qcode": "no",
+            "scheme": "sttpictureinvoiced"
+          }
+        ]
+      },
+      "profile": "68db9970f7bdb22537301b68",
+      "scheduled_updates": [],
+      "workflow_status": "assigned"
+    }
+  ],
+  "description_text": "Test Description",
+  "events": [],
+  "expired": false,
+  "firstcreated": "2025-10-28T10:13:10+0000",
+  "flags": {
+    "marked_for_not_publication": false,
+    "overide_auto_assign_to_workflow": false
+  },
+  "guid": "f2158efe-aaec-4e77-8ea3-5c9b53f218eb",
+  "headline": "Test Planning Headline",
+  "internal_note": "Test Planning Internal Note",
+  "item_class": "plinat:newscoverage",
+  "item_id": "f2158efe-aaec-4e77-8ea3-5c9b53f218eb",
+  "language": "fi",
+  "languages": [
+    "fi"
+  ],
+  "lock_action": "edit",
+  "lock_session": "69009183985c980a84842847",
+  "lock_time": "2025-10-28T10:13:32+0000",
+  "lock_user": "6900917d30291cb7d85a283e",
+  "original_creator": "6900917d30291cb7d85a283e",
+  "place": [],
+  "planning_date": "2025-10-28T00:00:00+0000",
+  "priority": 1,
+  "products": [
+    {
+      "code": "6900929452052e3573902b53",
+      "name": "All Planning"
+    }
+  ],
+  "pubstatus": "usable",
+  "slugline": "Test Slugline",
+  "state": "scheduled",
+  "state_reason": null,
+  "subject": [
+    {
+      "name": "Test Topic",
+      "parent": "20000550",
+      "qcode": "20000568",
+      "scheme": "topics"
+    },
+    {
+      "name": "US tarkastanut",
+      "qcode": "US tarkastanut",
+      "scheme": "sttcheckedby"
+    },
+    {
+      "name": "Pääaihe (3 300)",
+      "qcode": "stturgency-1",
+      "scheme": "stturgency"
+    }
+  ],
+  "type": "planning",
+  "version_creator": "6900917d30291cb7d85a283e",
+  "versioncreated": "2025-10-28T10:13:35+0000",
+  "versionposted": "2025-10-28T10:13:35+0000"
+}

--- a/server/tests/fixtures/json/stt_json_planning_item.json
+++ b/server/tests/fixtures/json/stt_json_planning_item.json
@@ -11,6 +11,11 @@
       "name": "Julkishallinnon tiedotepalvelu",
       "qcode": "2",
       "scheme": null
+    },
+    {
+      "name": "Urheilu",
+      "qcode": "16",
+      "scheme": null
     }
   ],
   "coverages": [

--- a/server/tests/stt_json_planning_formatter_test.py
+++ b/server/tests/stt_json_planning_formatter_test.py
@@ -109,9 +109,10 @@ class STTJsonPlanningFormatterTest(TestCase):
             formatter.map_agenda_output(item)
             expected_agendas = [
                 {
-                    "_id": "Julkishallinnon tiedotepalvelu",
+                    "_id": "julkishallinnontiedotepalvelu",
                     "name": "Julkishallinnon tiedotepalvelu",
                 },
-                {"_id": "Muut kuin urheilu", "name": "Muut kuin urheilu"},
+                {"_id": "673f47ba1562ef05527e195c", "name": "Urheilu"},
+                {"_id": "673f47982c95fe4cab8ee67e", "name": "Muut kuin urheilu"},
             ]
             self.assertEqual(item["agendas"], expected_agendas)

--- a/server/tests/stt_json_planning_formatter_test.py
+++ b/server/tests/stt_json_planning_formatter_test.py
@@ -1,3 +1,5 @@
+import json
+import os
 from tests import TestCase
 from superdesk import get_resource_service
 from stt.stt_json_planning_formatter import STTJsonPlanningFormatter
@@ -6,6 +8,12 @@ from stt.stt_json_planning_formatter import STTJsonPlanningFormatter
 class STTJsonPlanningFormatterTest(TestCase):
     add_stt_cvs = True
     parse_source = False
+    fixture = "json/stt_json_planning_item.json"
+
+    def get_sample_item(self):
+        fixture_path = os.path.join(os.path.dirname(__file__), "fixtures", self.fixture)
+        with open(fixture_path, "r") as f:
+            return json.load(f)
 
     async def test_update_stt_urgency_mappings(self):
         async with self.app.app_context():
@@ -28,3 +36,82 @@ class STTJsonPlanningFormatterTest(TestCase):
                 self.assertEqual(subj["qcode"], expected_qcode)
                 self.assertEqual(subj["scheme"], "stturgency")
                 self.assertEqual(subj["name"], name_map[expected_qcode])
+
+    async def test_exclude_internal_planning_fields(self):
+        async with self.app.app_context():
+            formatter = STTJsonPlanningFormatter()
+            item = self.get_sample_item()
+
+            self.assertIn("internal_note", item)
+            self.assertTrue(
+                any(
+                    subj.get("scheme") == "sttcheckedby"
+                    for subj in item.get("subject", [])
+                )
+            )
+
+            formatter.exclude_internal_planning_fields(item)
+
+            self.assertNotIn("internal_note", item)
+            self.assertFalse(
+                any(
+                    subj.get("scheme") == "sttcheckedby"
+                    for subj in item.get("subject", [])
+                )
+            )
+            self.assertTrue(
+                any(
+                    subj.get("scheme") == "stturgency"
+                    for subj in item.get("subject", [])
+                )
+            )
+
+    async def test_exclude_internal_coverage_fields(self):
+        async with self.app.app_context():
+            formatter = STTJsonPlanningFormatter()
+            item = self.get_sample_item()
+
+            coverage = item["coverages"][0]
+            planning = coverage["planning"]
+            self.assertIn("headline", planning)
+            self.assertIn("location", planning)
+            self.assertIn("internal_note", planning)
+            self.assertIn("scheduled", planning)
+            fields = planning["fields"]
+            self.assertTrue(
+                any(field["field"] == "sttpicturewhatabout" for field in fields)
+            )
+            self.assertTrue(
+                any(field["field"] == "sttregistrationinfo" for field in fields)
+            )
+
+            formatter.exclude_internal_coverage_fields(item)
+
+            self.assertNotIn("headline", planning)
+            self.assertNotIn("location", planning)
+            self.assertNotIn("internal_note", planning)
+            self.assertIn("scheduled", planning)
+            fields_after = planning["fields"]
+            self.assertFalse(
+                any(field["field"] == "sttpicturewhatabout" for field in fields_after)
+            )
+            self.assertFalse(
+                any(field["field"] == "sttregistrationinfo" for field in fields_after)
+            )
+
+    async def test_map_agendas(self):
+        async with self.app.app_context():
+            formatter = STTJsonPlanningFormatter()
+            item = self.get_sample_item()
+
+            self.assertEqual(item["agendas"], [])
+
+            formatter.map_agenda_output(item)
+            expected_agendas = [
+                {
+                    "_id": "Julkishallinnon tiedotepalvelu",
+                    "name": "Julkishallinnon tiedotepalvelu",
+                },
+                {"_id": "Muut kuin urheilu", "name": "Muut kuin urheilu"},
+            ]
+            self.assertEqual(item["agendas"], expected_agendas)


### PR DESCRIPTION
### Purpose
This PR adjusts the STT JSON output with the expectations by removing internal fields from planning and coverage fields and mapping agendas from anpa_category

### What has changed
- Added function to remove internal fields from the planning item.
- Added function to remove internal fields from the coverage items.
- Added function to map the anpa_category into the agendas field.
 
 ### 
 [STT-1422](https://sofab.atlassian.net/browse/STT-1422)

[STT-1422]: https://sofab.atlassian.net/browse/STT-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ