### PR TITLE
Feature/lupaus report published section and tweaks

### DIFF
--- a/server/stt/helpers/mongo_helpers.py
+++ b/server/stt/helpers/mongo_helpers.py
@@ -72,3 +72,180 @@ def find_many(
             )
 
     return []
+
+
+def get_published_items_with_sttnewsroomnote_by_planning_id(
+    planning_id: str,
+) -> List[Dict[str, Any]]:
+    """Return published items linked to *planning_id* via coverage assignments.
+    Return a list of published item documents that have a subject with scheme 'sttnewsroomnote'.
+
+    Executes the aggregation pipeline:
+
+        match planning -> compute sttimagetype from graphic coverage -> unwind coverages ->
+        convert assignment_id to ObjectId -> filter null assignments -> lookup published ->
+        unwind -> merge sttimagetype into the published document.
+
+    Any errors during aggregation are logged and result in an empty list.
+    """
+
+    try:
+        planning_service = get_resource_service("planning")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            "Error using service for planning (%s: %s)",
+            exc.__class__.__name__,
+            exc,
+        )
+        return []
+
+    collection = getattr(planning_service, "collection", None)
+    if collection is None:
+        backend = getattr(planning_service, "backend", None)
+        if backend is not None:
+            collection = getattr(backend, "collection", None) or getattr(
+                backend, "_collection", None
+            )
+    if collection is None:
+        try:  # Last-resort: pull the collection directly from the app's Mongo driver
+            from flask import current_app
+
+            collection = current_app.data.driver.db["planning"]
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Unable to access planning Mongo collection via service/driver (%s: %s)",
+                exc.__class__.__name__,
+                exc,
+            )
+            return []
+
+    pipeline = [
+        {"$match": {"_id": planning_id}},
+        {
+            # 1) Compute sttimagetype from the *graphic* coverage (once per planning doc)
+            "$set": {
+                "sttimagetype": {
+                    "$let": {
+                        "vars": {
+                            # first coverage where planning.g2_content_type == "graphic"
+                            "graphicCoverage": {
+                                "$first": {
+                                    "$filter": {
+                                        "input": "$coverages",
+                                        "as": "c",
+                                        "cond": {
+                                            "$eq": [
+                                                "$$c.planning.g2_content_type",
+                                                "graphic",
+                                            ]
+                                        },
+                                    }
+                                }
+                            },
+                            "subjects": {
+                                "$let": {
+                                    "vars": {
+                                        "gc": {
+                                            "$first": {
+                                                "$filter": {
+                                                    "input": "$coverages",
+                                                    "as": "c",
+                                                    "cond": {
+                                                        "$eq": [
+                                                            "$$c.planning.g2_content_type",
+                                                            "graphic",
+                                                        ]
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "in": {"$ifNull": ["$$gc.planning.subject", []]},
+                                }
+                            },
+                        },
+                        "in": {
+                            "$let": {
+                                "vars": {
+                                    "match": {
+                                        "$first": {
+                                            "$filter": {
+                                                "input": "$$subjects",
+                                                "as": "s",
+                                                "cond": {
+                                                    "$eq": [
+                                                        "$$s.scheme",
+                                                        "sttimagetype",
+                                                    ]
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                                "in": {
+                                    "$ifNull": [
+                                        "$$match.qcode",
+                                        {"$ifNull": ["$$match.name", ""]},
+                                    ]
+                                },
+                            }
+                        },
+                    }
+                }
+            }
+        },
+        # 2) Work per-coverage to find the one(s) that have assignment_id, and join to published
+        {"$unwind": "$coverages"},
+        {
+            # Convert assignment id (string) -> ObjectId
+            "$addFields": {
+                "assignment_id_obj": {
+                    "$convert": {
+                        "input": "$coverages.assigned_to.assignment_id",
+                        "to": "objectId",
+                        "onError": None,
+                        "onNull": None,
+                    }
+                }
+            }
+        },
+        # Only keep coverages where we do have a valid assignment id
+        {"$match": {"assignment_id_obj": {"$ne": None}}},
+        {
+            # 3) Lookup published with filters
+            "$lookup": {
+                "from": "published",
+                "let": {"aobj": "$assignment_id_obj"},
+                "pipeline": [
+                    {
+                        "$match": {
+                            "$expr": {"$eq": ["$assignment_id", "$$aobj"]},
+                            "state": "published",
+                            "subject": {"$elemMatch": {"scheme": "sttnewsroomnote"}},
+                        }
+                    }
+                ],
+                "as": "pub",
+            }
+        },
+        {"$unwind": "$pub"},
+        {
+            # 4) Merge the precomputed sttimagetype into each published doc
+            "$replaceRoot": {
+                "newRoot": {
+                    "$mergeObjects": ["$pub", {"sttimagetype": "$sttimagetype"}]
+                }
+            }
+        },
+    ]
+
+    try:
+        return list(collection.aggregate(pipeline))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            "Error aggregating published items for planning %s (%s: %s)",
+            planning_id,
+            exc.__class__.__name__,
+            exc,
+        )
+        return []

--- a/server/stt/helpers/mongo_helpers.py
+++ b/server/stt/helpers/mongo_helpers.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from superdesk import get_resource_service
+from superdesk.core.app import get_current_async_app
 
 logger = logging.getLogger(__name__)
 
@@ -90,34 +91,15 @@ def get_published_items_with_sttnewsroomnote_by_planning_id(
     """
 
     try:
-        planning_service = get_resource_service("planning")
+        async_app = get_current_async_app()
+        collection = async_app.wsgi.data.get_mongo_collection("planning")
     except Exception as exc:  # pragma: no cover - defensive logging
         logger.exception(
-            "Error using service for planning (%s: %s)",
+            "Unable to access planning Mongo collection via service/driver (%s: %s)",
             exc.__class__.__name__,
             exc,
         )
         return []
-
-    collection = getattr(planning_service, "collection", None)
-    if collection is None:
-        backend = getattr(planning_service, "backend", None)
-        if backend is not None:
-            collection = getattr(backend, "collection", None) or getattr(
-                backend, "_collection", None
-            )
-    if collection is None:
-        try:  # Last-resort: pull the collection directly from the app's Mongo driver
-            from flask import current_app
-
-            collection = current_app.data.driver.db["planning"]
-        except Exception as exc:  # pragma: no cover - defensive logging
-            logger.exception(
-                "Unable to access planning Mongo collection via service/driver (%s: %s)",
-                exc.__class__.__name__,
-                exc,
-            )
-            return []
 
     pipeline = [
         {"$match": {"_id": planning_id}},

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -1,7 +1,10 @@
 from typing import Dict, List, Any, Set
 import logging
 
-from stt.helpers.mongo_helpers import find_many
+from stt.helpers.mongo_helpers import (
+    find_many,
+    get_published_items_with_sttnewsroomnote_by_planning_id,
+)
 from stt.helpers.template_helpers import exclude_drafts
 
 logger = logging.getLogger(__name__)
@@ -223,6 +226,39 @@ def _set_priority_fields(pl: Dict[str, Any]) -> None:
     pl["stt_priority_numeric"] = priority_numeric
 
 
+def _get_latest_published_item(
+    published_items: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Returns the latest published item from a list based on 'versioncreated'.
+    If the list is empty, returns an empty dictionary.
+    Args:
+        published_items: A list of published item dictionaries.
+    Returns:
+        The latest published item dictionary, or an empty dictionary if the list is empty.
+    """
+    if not published_items:
+        return {}
+    # first filter out items that do not have subject with scheme 'sttnewsroomnote' and qcode "nootherversions", "printformat" or "validforprint"
+    filtered_items = [
+        item
+        for item in published_items
+        if any(
+            sub.get("scheme") == "sttnewsroomnote"
+            and sub.get("qcode") in ["nootherversions", "printformat", "validforprint"]
+            for sub in item.get("subject", [])
+        )
+    ]
+    if not filtered_items:
+        return {}
+    # get latest item from filtered_items by versioncreated (datetime string)
+    latest_item = max(
+        filtered_items,
+        key=lambda item: item.get("versioncreated", ""),
+    )
+    return latest_item
+
+
 def _set_stt_fields(
     agendas: List[Dict[str, Any]],
     by_key: Dict[str, Dict[str, Any]],
@@ -243,6 +279,13 @@ def _set_stt_fields(
                 pl, item_type
             )
             pl["news_coverage_status"] = news_coverage_status
+            # try to get latest published item with sttnewsroomnote subject
+            published_related_items = (
+                get_published_items_with_sttnewsroomnote_by_planning_id(pl.get("_id"))
+            )
+            latest_published_item = _get_latest_published_item(published_related_items)
+            # attach latest published item to planning item
+            pl["latest_published_item"] = latest_published_item
             _set_priority_fields(pl)
             if not pl.get("stt_priority"):
                 continue  # exclude items without priority

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -51,58 +51,111 @@ def _collect_event_ids(agendas: List[Dict[str, Any]]) -> List[str]:
     return list(ids)
 
 
-def _get_planning_item_coverage_status_from_mongo(
-    pl: Dict[str, Any], item_type: str
+def _get_planning_coverages_metadata(
+    pl: Dict[str, Any],
+    item_type: str,
+    imagetypes: bool = False,
 ) -> Dict[str, Any]:
+    """Return coverage metadata for a planning item, fetching from Mongo if needed.
+
+    When ``imagetypes`` is ``False`` (default) this
+    returns the first available ``news_coverage_status`` mapping from the item's
+    coverages. When ``imagetypes`` is ``True`` the function instead collects all
+    ``sttimagetype`` subject ``name`` values from the coverages and returns them as
+    ``{"imagetypes": [...]}``.
+
+    The function first inspects the in-memory planning item and only falls back to a
+    Mongo query when the desired information is missing locally.
     """
-    For some reason item.coverages might be like coverages': ['Kuvauskeikka', 'Kuvitus', 'Uutisteksti']
-    but we need "planning.coverages.news_coverage_status"-data from mongo by item _id
-    Get the 'news_coverage_status' from the 'coverages' of a planning item if it does not exist in the item.
-    Args:
-        pl: A dictionary representing a planning item.
-        item_type: The type of the planning item, e.g., 'teksti' / 'kuva'.
-    Returns:
-        The value of 'news_coverage_status' if found, otherwise an empty dictionary.
-    """
+
     if not pl:
         return {}
-    # skip if no coverages
-    if "coverages" not in pl or not pl["coverages"]:
-        return {}
-    # Check if item already has news_coverage_status
-    for cov in pl["coverages"]:
-        if "news_coverage_status" in cov and cov["news_coverage_status"]:
-            return cov["news_coverage_status"]
-    pl_id = pl.get("_id")
-    # skip if no id for some reason
-    if not pl_id:
-        return {}
-    if item_type == "kuva":
-        pl_from_mongo = find_many(
-            "planning",
-            # get only coverages that have "planning.g2_content_type" = "graphic" or "picture"
-            {
-                "_id": pl_id,
-                "coverages.planning.g2_content_type": {"$in": ["graphic", "picture"]},
-            },
-            projection={"coverages": 1, "_id": 0},
-        )
-    else:
-        pl_from_mongo = find_many(
-            "planning",
-            # get only coverages that have "planning.g2_content_type" = "text"
-            {"_id": pl_id, "coverages.planning.g2_content_type": "text"},
-            projection={"coverages": 1, "_id": 0},
-        )
-    if not pl_from_mongo:
-        return {}
-    if ("coverages" not in pl_from_mongo[0]) or (not pl_from_mongo[0]["coverages"]):
-        return {}
 
-    for cov in pl_from_mongo[0]["coverages"]:
-        if "news_coverage_status" in cov and cov["news_coverage_status"]:
-            return cov["news_coverage_status"]
+    coverages = [cov for cov in pl.get("coverages") or [] if isinstance(cov, dict)]
+
+    imagetypes_local: List[str] = []
+    if imagetypes:
+        imagetypes_local = _collect_imagetypes_from_coverages(coverages)
+        if imagetypes_local:
+            return {"imagetypes": imagetypes_local}
+    else:
+        status = _extract_news_coverage_status(coverages)
+        if status:
+            return status
+
+    pl_id = pl.get("_id")
+    if not pl_id:
+        return {"imagetypes": imagetypes_local} if imagetypes else {}
+
+    coverages_from_db = _load_coverages_from_mongo(pl_id, item_type)
+    if not coverages_from_db:
+        return {"imagetypes": imagetypes_local} if imagetypes else {}
+
+    if imagetypes:
+        image_coverage_types = _collect_imagetypes_from_coverages(coverages_from_db)
+        return {"imagetypes": image_coverage_types}
+
+    return _extract_news_coverage_status(coverages_from_db)
+
+
+def _extract_news_coverage_status(coverages: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return the first non-empty ``news_coverage_status`` mapping from coverages."""
+
+    for cov in coverages:
+        status = cov.get("news_coverage_status")
+        if status:
+            return status
     return {}
+
+
+def _collect_imagetypes_from_coverages(coverages: List[Dict[str, Any]]) -> List[str]:
+    """Collect unique ``sttimagetype`` subject names from coverage planning data."""
+
+    seen: Set[str] = set()
+    imagetypes: List[str] = []
+    for cov in coverages:
+        planning = cov.get("planning")
+        if not isinstance(planning, dict):
+            continue
+        subjects = planning.get("subject")
+        if not isinstance(subjects, list):
+            continue
+        for sub in subjects:
+            if not isinstance(sub, dict) or sub.get("scheme") != "sttimagetype":
+                continue
+            name = sub.get("name") or sub.get("qcode")
+            if name and name not in seen:
+                seen.add(name)
+                imagetypes.append(name)
+    return imagetypes
+
+
+def _load_coverages_from_mongo(pl_id: str, item_type: str) -> List[Dict[str, Any]]:
+    """Fetch coverages for a planning item directly from Mongo using ``find_many``."""
+
+    if not pl_id:
+        return []
+
+    if item_type == "kuva":
+        lookup = {
+            "_id": pl_id,
+            "coverages.planning.g2_content_type": {"$in": ["graphic", "picture"]},
+        }
+    else:
+        lookup = {
+            "_id": pl_id,
+            "coverages.planning.g2_content_type": "text",
+        }
+
+    docs = find_many("planning", lookup, projection={"coverages": 1, "_id": 0})
+    if not docs:
+        return []
+
+    coverages = docs[0].get("coverages") if isinstance(docs[0], dict) else None
+    if not isinstance(coverages, list):
+        return []
+
+    return [cov for cov in coverages if isinstance(cov, dict)]
 
 
 def get_priority_from_agenda_item(item: Dict[str, Any]) -> str:
@@ -275,10 +328,14 @@ def _set_stt_fields(
     for ag in agendas or []:
         new_items: List[Dict[str, Any]] = []
         for pl in ag.get("items") or []:
-            news_coverage_status = _get_planning_item_coverage_status_from_mongo(
-                pl, item_type
-            )
+            # get news_coverage_status for planning item
+            news_coverage_status = _get_planning_coverages_metadata(pl, item_type)
             pl["news_coverage_status"] = news_coverage_status
+            # get sttimagetypes for planning item (always use "kuva" as item_type to get image types)
+            item_imagetypes = _get_planning_coverages_metadata(
+                pl, "kuva", imagetypes=True
+            )
+            pl["sttimagetypes"] = item_imagetypes.get("imagetypes") or []
             # try to get latest published item with sttnewsroomnote subject
             published_related_items = (
                 get_published_items_with_sttnewsroomnote_by_planning_id(pl.get("_id"))
@@ -335,6 +392,18 @@ def _group_agenda_items_by_category(
         if category_name not in categorized_items:
             categorized_items[category_name] = []
         categorized_items[category_name].append(pl)
+    # sort categories like: Kotimaa, Politiikka, Talous, Kulttuuri, Ulkomaat, Urheilu
+    sorted_categories = [
+        "Kotimaa",
+        "Politiikka",
+        "Talous",
+        "Kulttuuri",
+        "Ulkomaat",
+        "Urheilu",
+    ]
+    categorized_items = {
+        k: categorized_items[k] for k in sorted_categories if k in categorized_items
+    }
     return categorized_items
 
 

--- a/server/templates/kuvalupaus_events_template.html
+++ b/server/templates/kuvalupaus_events_template.html
@@ -14,10 +14,8 @@
 
 {# Macro to render a single planning item category from subject -> scheme = "categories" #}
 {% macro render_planning_item_category(item) -%}
-  {%- for sub in item.subject | default([]) -%}
-    {%- if sub.scheme == "categories" -%}
-      ({{ sub.name | upper }})
-    {%- endif -%}
+  {%- for sub in item.anpa_category | default([]) -%}
+    ({{ sub.name | upper }})
   {%- endfor -%}
 {%- endmacro %}
 
@@ -25,48 +23,36 @@
 {% macro render_planning_item(item) -%}
   {%- set bits = [] -%}
   {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
-  {%- if item.description_text %}{% set _ = bits.append(item.description_text) %}{% endif -%}
-  {%- for ev in item.related_events_expanded or [] -%}
-    {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
-    {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
-    {%- if ev.location is iterable -%}
-      {%- set ev_loc = lupaus_location(ev.location) -%}
-      {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
-    {%- endif -%}
-  {%- endfor -%}
   {# Add coverages if available #}
-  {%- if item.coverages is defined and item.coverages -%}
-    {%- set cov_list = item.coverages if item.coverages is iterable else [item.coverages] -%}
+  {%- if item.sttimagetypes -%}
+    {%- set cov_list = item.sttimagetypes if item.sttimagetypes is iterable else [item.sttimagetypes] -%}
     {%- if cov_list | length > 0 -%}
-      {%- set _ = bits.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
+      {%- set _ = bits.append((cov_list | join(', '))) -%}
     {%- endif -%}
   {%- endif -%}
-  {%- if bits %}<p>- {{- bits | join(', ') -}}.</p>{% endif -%}
-  <p></p>
+  {%- if bits %}<p>{{- bits | join('. ') -}}.</p>{% endif -%}
 {%- endmacro %}
 
 {# Macro to render a single main topic item paragraph #}
 {% macro render_main_topic_item(item) -%}
   {%- set bits = [] -%}
-  {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
+    {%- if item.slugline -%}
+      {%- set slug = item.slugline | trim -%}
+      {%- if slug.endswith('?') -%}
+        {% set _ = bits.append(slug) %}
+      {%- else -%}
+        {% set _ = bits.append(slug ~ '.') %}
+      {%- endif -%}
+    {%- endif -%}
   {%- set category_str = render_planning_item_category(item) -%}
   {%- if category_str %}
-  {# category uppercase #}
-    {% set _ = bits.append(category_str | upper) %}
-  {% endif -%}
-  {%- if bits %}<p>- {{- bits | join(' ') -}}.</p>{% endif -%}
-  <p></p>
+    {% set _ = bits.append(category_str) %}
+  {%- endif -%}
+  {%- if bits %}<p>{{- bits | join(' ') -}}</p>{% endif -%}
 {%- endmacro %}
 
 {# One paragraph per agenda item; grouped by category if grouped_items present #}
 {%- for agenda in agendas or [] -%}
-  {%- set main_topic_items = agenda.get('main_topic_items') -%}
-  {%- if main_topic_items and main_topic_items | count > 0 -%}
-    <h2>KÄRKIAIHEITAMME</h2>
-    {%- for item in main_topic_items -%}
-      {{ render_main_topic_item(item) }}
-    {%- endfor -%}
-  {%- endif -%}
   {%- set grouped = agenda.get('grouped_items') -%}
   {%- if grouped and grouped.items() | count > 0 -%}
     {%- for category, items in grouped.items() -%}

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -14,10 +14,8 @@
 
 {# Macro to render a single planning item category from subject -> scheme = "categories" #}
 {% macro render_planning_item_category(item) -%}
-  {%- for sub in item.subject | default([]) -%}
-    {%- if sub.scheme == "categories" -%}
-      ({{ sub.name | upper }})
-    {%- endif -%}
+  {%- for sub in item.anpa_category | default([]) -%}
+    ({{ sub.name | upper }})
   {%- endfor -%}
 {%- endmacro %}
 
@@ -37,7 +35,15 @@
 {# Macro to render a single planning item paragraph (reused for grouped & ungrouped) #}
 {% macro render_planning_item(item) -%}
   {%- set bits = [] -%}
-  {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
+    {%- if item.slugline -%}
+      {%- set slug = item.slugline | trim -%}
+      {# Check if slug ends with a question mark or not and if not add a period to the end #}
+      {%- if slug.endswith('?') -%}
+        {% set _ = bits.append(slug) %}
+      {%- else -%}
+        {% set _ = bits.append(slug ~ '.') %}
+      {%- endif -%}
+    {%- endif -%}
   {%- if item.latest_published_item and item.latest_published_item._id -%}
     {%- set pub_item = item.latest_published_item -%}
     {%- if pub_item.headline %}{% set _ = bits.append('"' ~ pub_item.headline ~ '"') %}{% endif -%}
@@ -66,8 +72,8 @@
     {%- set urg = stt_priority_text(item) -%}
     {%- if urg %}{% set _ = bits.append(urg) %}{% endif -%}
     {# Add coverages if available #}
-    {%- if item.coverages is defined and item.coverages -%}
-      {%- set cov_list = item.coverages if item.coverages is iterable else [item.coverages] -%}
+    {%- if item.sttimagetypes -%}
+      {%- set cov_list = item.sttimagetypes if item.sttimagetypes is iterable else [item.sttimagetypes] -%}
       {%- if cov_list | length > 0 -%}
         {%- set _ = bits.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
       {%- endif -%}
@@ -80,10 +86,19 @@
 {# Macro to render a single main topic item paragraph #}
 {% macro render_main_topic_item(item) -%}
   {%- set bits = [] -%}
-  {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
+    {%- if item.slugline -%}
+      {%- set slug = item.slugline | trim -%}
+      {%- if slug.endswith('?') -%}
+        {% set _ = bits.append(slug) %}
+      {%- else -%}
+        {% set _ = bits.append(slug ~ '.') %}
+      {%- endif -%}
+    {%- endif -%}
   {%- set category_str = render_planning_item_category(item) -%}
-  {%- if category_str %}{% set _ = bits.append(category_str) %}{% endif -%}
-  {%- if bits %}<p>- {{- bits | join(' ') -}}.</p>{% endif -%}
+  {%- if category_str %}
+    {% set _ = bits.append(category_str) %}
+  {%- endif -%}
+  {%- if bits %}<p>- {{- bits | join(' ') -}}</p>{% endif -%}
   <p></p>
 {%- endmacro %}
 
@@ -112,13 +127,13 @@
   {%- if grouped and grouped.items() | count > 0 -%}
     {%- for category, items in grouped.items() -%}
       <h2>{{ category | upper }}</h2>
-      {%- set coverage = namespace(intended=[], undecided=[], other=[], send=[]) -%}
+      {%- set coverage = namespace(intended=[], undecided=[], other=[], sent=[]) -%}
       {%- for item in items -%}
         {%- set status = item.news_coverage_status or {} -%}
         {%- set status_name = (status.name or '') | lower -%}
-        {# If item has "latest_published_item", add it to coverage.send and skip the coverage status_name checks #}
+        {# If item has "latest_published_item", add it to coverage.sent and skip the coverage status_name checks #}
         {%- if item.latest_published_item and item.latest_published_item._id -%}
-          {%- set _ = coverage.send.append(item) -%}
+          {%- set _ = coverage.sent.append(item) -%}
         {%- elif status_name == 'coverage intended' -%}
           {%- set _ = coverage.intended.append(item) -%}
         {%- elif status_name == 'coverage not decided yet' -%}
@@ -132,9 +147,9 @@
         {{ render_planning_item(item) }}
       {%- endfor -%}
 
-      {%- if coverage.send -%}
+      {%- if coverage.sent -%}
         <h3>LÄHETETYT</h3>
-        {%- for item in coverage.send -%}
+        {%- for item in coverage.sent -%}
           {{ render_planning_item(item) }}
         {%- endfor -%}
       {%- endif -%}
@@ -166,8 +181,8 @@
 <p>Mittaversio = Mittaan kirjoitettu uutisversio, jonka muotoilut sopivat printille. Versiotyyppinä pika+, joten sopii myös verkkokäyttöön.</p>
 <p>Ystävällisin terveisin,<br />
 Uutispäälliköt<br />
-Klo 6.30-14 Merja Könönen<br />
-Klo 13.30-21 Tapio Pellinen<br />
+Klo 6.30-14<br />
+Klo 13.30-21<br />
 p. 09 - 695 81 327<br />
 uutispaallikot@stt.fi
 </p>

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -34,23 +34,25 @@
 
 {# Macro to render a single planning item paragraph (reused for grouped & ungrouped) #}
 {% macro render_planning_item(item) -%}
-  {%- set bits = [] -%}
+  {%- set first_parts = [] -%}
+  {%- set second_parts = [] -%}
+  {%- set third_parts = [] -%}
     {%- if item.slugline -%}
       {%- set slug = item.slugline | trim -%}
       {# Check if slug ends with a question mark or not and if not add a period to the end #}
       {%- if slug.endswith('?') -%}
-        {% set _ = bits.append(slug) %}
+        {% set _ = first_parts.append(slug) %}
       {%- else -%}
-        {% set _ = bits.append(slug ~ '.') %}
+        {% set _ = first_parts.append(slug ~ '.') %}
       {%- endif -%}
     {%- endif -%}
   {%- if item.latest_published_item and item.latest_published_item._id -%}
     {%- set pub_item = item.latest_published_item -%}
-    {%- if pub_item.headline %}{% set _ = bits.append('"' ~ pub_item.headline ~ '"') %}{% endif -%}
-    {%- if pub_item.body_html %}{% set _ = bits.append((pub_item.body_html | count_body_html_characters) ~ " merkkiä (lähetetty)") %}{% endif -%}
-    {%- if pub_item.sttimagetype %}{% set _ = bits.append('Kuvitus: ' ~ (pub_item.sttimagetype)) %}{% endif -%}
+    {%- if pub_item.headline %}{% set _ = second_parts.append('"' ~ pub_item.headline ~ '"') %}{% endif -%}
+    {%- if pub_item.body_html %}{% set _ = second_parts.append((pub_item.body_html | count_body_html_characters) ~ " merkkiä (lähetetty)") %}{% endif -%}
+    {%- if pub_item.sttimagetype %}{% set _ = second_parts.append('Kuvitus: ' ~ (pub_item.sttimagetype)) %}{% endif -%}
   {%- else -%}
-    {%- if item.description_text %}{% set _ = bits.append(item.description_text) %}{% endif -%}
+    {%- if item.description_text %}{% set _ = second_parts.append(item.description_text) %}{% endif -%}
     {%- for ev in item.related_events_expanded or [] -%}
       {%- set ev_subjects = ev.subject | default([]) -%}
       {%- set is_competition = ev_subjects
@@ -60,27 +62,28 @@
         | length > 0 -%}
         {# Do not include event details if it is a competition #}
       {%- if not is_competition -%}
-        {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
-        {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
+        {%- if ev.name and ev.name != item.slugline %}{% set _ = second_parts.append(ev.name) %}{% endif -%}
+        {%- if ev.dates and ev.dates.start %}{% set _ = second_parts.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
         {%- if ev.location is iterable -%}
           {%- set ev_loc = lupaus_location(ev.location) -%}
-          {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
+          {%- if ev_loc %}{% set _ = second_parts.append(ev_loc) %}{% endif -%}
         {%- endif -%}
       {%- endif -%}
     {%- endfor -%}
     {# Call the priority macro #}
     {%- set urg = stt_priority_text(item) -%}
-    {%- if urg %}{% set _ = bits.append(urg) %}{% endif -%}
+    {%- if urg %}{% set _ = third_parts.append(urg) %}{% endif -%}
     {# Add coverages if available #}
     {%- if item.sttimagetypes -%}
       {%- set cov_list = item.sttimagetypes if item.sttimagetypes is iterable else [item.sttimagetypes] -%}
       {%- if cov_list | length > 0 -%}
-        {%- set _ = bits.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
+        {%- set _ = third_parts.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
       {%- endif -%}
     {%- endif -%}
   {%- endif -%}
-  {%- if bits %}<p>- {{- bits | join(', ') -}}.</p>{% endif -%}
-  <p></p>
+  {%- if first_parts %}
+    <p>- {{ first_parts | join(', ') }}{% if second_parts %} {{ second_parts | join(', ') }}.{% endif %}{% if third_parts %} {{ third_parts | join(', ') }}.{% endif %}</p>
+  {% endif -%}
 {%- endmacro %}
 
 {# Macro to render a single main topic item paragraph #}
@@ -99,7 +102,6 @@
     {% set _ = bits.append(category_str) %}
   {%- endif -%}
   {%- if bits %}<p>- {{- bits | join(' ') -}}</p>{% endif -%}
-  <p></p>
 {%- endmacro %}
 
 {# Actual rendering logic for the agenda items starts here #}

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -38,32 +38,39 @@
 {% macro render_planning_item(item) -%}
   {%- set bits = [] -%}
   {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
-  {%- if item.description_text %}{% set _ = bits.append(item.description_text) %}{% endif -%}
-  {%- for ev in item.related_events_expanded or [] -%}
-    {%- set ev_subjects = ev.subject | default([]) -%}
-    {%- set is_competition = ev_subjects
-      | selectattr('scheme', 'equalto', 'event_type')
-      | selectattr('name', 'equalto', 'Kilpailut')
-      | list
-      | length > 0 -%}
-      {# Do not include event details if it is a competition #}
-    {%- if not is_competition -%}
-      {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
-      {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
-      {%- if ev.location is iterable -%}
-        {%- set ev_loc = lupaus_location(ev.location) -%}
-        {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
+  {%- if item.latest_published_item and item.latest_published_item._id -%}
+    {%- set pub_item = item.latest_published_item -%}
+    {%- if pub_item.headline %}{% set _ = bits.append('"' ~ pub_item.headline ~ '"') %}{% endif -%}
+    {%- if pub_item.body_html %}{% set _ = bits.append((pub_item.body_html | count_body_html_characters) ~ " merkkiä (lähetetty)") %}{% endif -%}
+    {%- if pub_item.sttimagetype %}{% set _ = bits.append('Kuvitus: ' ~ (pub_item.sttimagetype)) %}{% endif -%}
+  {%- else -%}
+    {%- if item.description_text %}{% set _ = bits.append(item.description_text) %}{% endif -%}
+    {%- for ev in item.related_events_expanded or [] -%}
+      {%- set ev_subjects = ev.subject | default([]) -%}
+      {%- set is_competition = ev_subjects
+        | selectattr('scheme', 'equalto', 'event_type')
+        | selectattr('name', 'equalto', 'Kilpailut')
+        | list
+        | length > 0 -%}
+        {# Do not include event details if it is a competition #}
+      {%- if not is_competition -%}
+        {%- if ev.name and ev.name != item.slugline %}{% set _ = bits.append(ev.name) %}{% endif -%}
+        {%- if ev.dates and ev.dates.start %}{% set _ = bits.append('klo ' ~ (ev.dates.start | fi_time)) %}{% endif -%}
+        {%- if ev.location is iterable -%}
+          {%- set ev_loc = lupaus_location(ev.location) -%}
+          {%- if ev_loc %}{% set _ = bits.append(ev_loc) %}{% endif -%}
+        {%- endif -%}
       {%- endif -%}
-    {%- endif -%}
-  {%- endfor -%}
-  {# Call the priority macro #}
-  {%- set urg = stt_priority_text(item) -%}
-  {%- if urg %}{% set _ = bits.append(urg) %}{% endif -%}
-  {# Add coverages if available #}
-  {%- if item.coverages is defined and item.coverages -%}
-    {%- set cov_list = item.coverages if item.coverages is iterable else [item.coverages] -%}
-    {%- if cov_list | length > 0 -%}
-      {%- set _ = bits.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
+    {%- endfor -%}
+    {# Call the priority macro #}
+    {%- set urg = stt_priority_text(item) -%}
+    {%- if urg %}{% set _ = bits.append(urg) %}{% endif -%}
+    {# Add coverages if available #}
+    {%- if item.coverages is defined and item.coverages -%}
+      {%- set cov_list = item.coverages if item.coverages is iterable else [item.coverages] -%}
+      {%- if cov_list | length > 0 -%}
+        {%- set _ = bits.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
+      {%- endif -%}
     {%- endif -%}
   {%- endif -%}
   {%- if bits %}<p>- {{- bits | join(', ') -}}.</p>{% endif -%}
@@ -105,11 +112,14 @@
   {%- if grouped and grouped.items() | count > 0 -%}
     {%- for category, items in grouped.items() -%}
       <h2>{{ category | upper }}</h2>
-      {%- set coverage = namespace(intended=[], undecided=[], other=[]) -%}
+      {%- set coverage = namespace(intended=[], undecided=[], other=[], send=[]) -%}
       {%- for item in items -%}
         {%- set status = item.news_coverage_status or {} -%}
         {%- set status_name = (status.name or '') | lower -%}
-        {%- if status_name == 'coverage intended' -%}
+        {# If item has "latest_published_item", add it to coverage.send and skip the coverage status_name checks #}
+        {%- if item.latest_published_item and item.latest_published_item._id -%}
+          {%- set _ = coverage.send.append(item) -%}
+        {%- elif status_name == 'coverage intended' -%}
           {%- set _ = coverage.intended.append(item) -%}
         {%- elif status_name == 'coverage not decided yet' -%}
           {%- set _ = coverage.undecided.append(item) -%}
@@ -121,6 +131,13 @@
       {%- for item in coverage.intended -%}
         {{ render_planning_item(item) }}
       {%- endfor -%}
+
+      {%- if coverage.send -%}
+        <h3>LÄHETETYT</h3>
+        {%- for item in coverage.send -%}
+          {{ render_planning_item(item) }}
+        {%- endfor -%}
+      {%- endif -%}
 
       {%- if coverage.undecided -%}
         <h2>JOS AIHETTA</h2>

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -14,10 +14,8 @@
 
 {# Macro to render a single planning item category from subject -> scheme = "categories" #}
 {% macro render_planning_item_category(item) -%}
-  {%- for sub in item.subject | default([]) -%}
-    {%- if sub.scheme == "categories" -%}
-      ({{ sub.name | upper }})
-    {%- endif -%}
+  {%- for sub in item.anpa_category | default([]) -%}
+    ({{ sub.name | upper }})
   {%- endfor -%}
 {%- endmacro %}
 
@@ -37,7 +35,15 @@
 {# Macro to render a single planning item paragraph (reused for grouped & ungrouped) #}
 {% macro render_planning_item(item) -%}
   {%- set bits = [] -%}
-  {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
+    {%- if item.slugline -%}
+      {%- set slug = item.slugline | trim -%}
+      {# Check if slug ends with a question mark or not and if not add a period to the end #}
+      {%- if slug.endswith('?') -%}
+        {% set _ = bits.append(slug) %}
+      {%- else -%}
+        {% set _ = bits.append(slug ~ '.') %}
+      {%- endif -%}
+    {%- endif -%}
   {%- if item.latest_published_item and item.latest_published_item._id -%}
     {%- set pub_item = item.latest_published_item -%}
     {%- if pub_item.headline %}{% set _ = bits.append('"' ~ pub_item.headline ~ '"') %}{% endif -%}
@@ -66,8 +72,8 @@
     {%- set urg = stt_priority_text(item) -%}
     {%- if urg %}{% set _ = bits.append(urg) %}{% endif -%}
     {# Add coverages if available #}
-    {%- if item.coverages is defined and item.coverages -%}
-      {%- set cov_list = item.coverages if item.coverages is iterable else [item.coverages] -%}
+    {%- if item.sttimagetypes -%}
+      {%- set cov_list = item.sttimagetypes if item.sttimagetypes is iterable else [item.sttimagetypes] -%}
       {%- if cov_list | length > 0 -%}
         {%- set _ = bits.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
       {%- endif -%}
@@ -80,10 +86,19 @@
 {# Macro to render a single main topic item paragraph #}
 {% macro render_main_topic_item(item) -%}
   {%- set bits = [] -%}
-  {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
+    {%- if item.slugline -%}
+      {%- set slug = item.slugline | trim -%}
+      {%- if slug.endswith('?') -%}
+        {% set _ = bits.append(slug) %}
+      {%- else -%}
+        {% set _ = bits.append(slug ~ '.') %}
+      {%- endif -%}
+    {%- endif -%}
   {%- set category_str = render_planning_item_category(item) -%}
-  {%- if category_str %}{% set _ = bits.append(category_str) %}{% endif -%}
-  {%- if bits %}<p>- {{- bits | join(' ') -}}.</p>{% endif -%}
+  {%- if category_str %}
+    {% set _ = bits.append(category_str) %}
+  {%- endif -%}
+  {%- if bits %}<p>- {{- bits | join(' ') -}}</p>{% endif -%}
   <p></p>
 {%- endmacro %}
 
@@ -166,8 +181,8 @@
 <p>Mittaversio = Mittaan kirjoitettu uutisversio, jonka muotoilut sopivat printille. Versiotyyppinä pika+, joten sopii myös verkkokäyttöön.</p>
 <p>Ystävällisin terveisin,<br />
 Uutispäälliköt<br />
-Klo 6.30-14 Merja Könönen<br />
-Klo 13.30-21 Tapio Pellinen<br />
+Klo 6.30-14<br />
+Klo 13.30-21<br />
 p. 09 - 695 81 327<br />
 uutispaallikot@stt.fi
 </p>


### PR DESCRIPTION
feat: surface latest newsroom note in Lupaus report
    
    - add `get_published_items_with_sttnewsroomnote_by_planning_id` helper that aggregates planning → published with fallback collection access
    - enrich planning items with the latest published newsroom note matching sttnewsroomnote qcodes
    - update Lupaus events template to display published headline, length, image type, and group sent coverages

feat: enrich Lupaus agenda with imagetype metadata
    
    - replace `_get_planning_item_coverage_status_from_mongo` with `_get_planning_coverages_metadata`, supporting both news coverage status and sttimagetype extraction
    - persist imagetypes on planning items and sort categories consistently in `enrich_related`
    - update Lupaus events template to render refined sluglines, use `sttimagetypes`, adjust category and footer output