### PR TITLE
[STT-1415] - Adjust STT Newsroom NINJS output format for Newshub

### DIFF
--- a/server/stt/stt_newsroom_ninjs_formatter.py
+++ b/server/stt/stt_newsroom_ninjs_formatter.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from superdesk.publish.formatters import NewsroomNinjsFormatter
 
@@ -14,7 +15,7 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
         self.can_export = False
         self.internal_renditions = ["original", "viewImage", "baseImage"]
 
-    def update_ninjs_stt_sources(self, ninjs):
+    def update_stt_sources(self, ninjs):
         try:
             stt_sources = [
                 subj["name"]
@@ -36,10 +37,64 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
 
             ninjs["source"] = "-".join(sorted_sources)
         except Exception as e:
-            logger.error(f"Error occurred when updating ninjs stt sources: {str(e)}")
+            logger.error(f"Error occurred when updating stt sources: {str(e)}")
+
+    def update_place(self, ninjs):
+        locators = [place.get("code") for place in ninjs.get("place", [])]
+        if locators:
+            ninjs["locators"] = locators
+
+    def update_body_from_content_profiles(self, ninjs):
+        extra = ninjs.get("extra", {})
+        profile = extra.get("content_profile_name", ninjs.get("profile"))
+        if not profile:
+            return
+        if profile.lower() in ("viiva", "sms"):
+            headline = ninjs.get("headline", "")
+            if headline:
+                body = ninjs.get("body_html", "")
+                ninjs["body_html"] = f"<p>{headline}</p>" + (body or "")
+
+    def update_subheadline(self, ninjs):
+        extra = ninjs.get("extra", {})
+        sttsubheadline = extra.get("sttsubheadline")
+        profile = extra.get("content_profile_name", ninjs.get("profile"))
+        if not sttsubheadline: 
+            return
+        if profile.lower() in ("pikaplus"):
+            text = re.sub(r"<[^>]+>", "", sttsubheadline).strip()
+            if not text:
+                text = sttsubheadline.strip()
+            header = f"<h2>{text}</h2>"
+            body = ninjs.get("body_html", "")
+            ninjs["body_html"] = header + (body or "")
+
+    def update_sttversion(self, ninjs):
+        extra = ninjs.get("extra", {})
+        profile = extra.get("content_profile_name", ninjs.get("profile"))
+        if not profile:
+            return
+        versions = str(profile).strip()
+        ninjs["sttversion"] = versions
+
+    def update_editorial_note(self, ninjs):
+        name = None
+        for subject in ninjs.get("subject", []):
+            if subject.get("scheme") == "sttnewsroomnote":
+                name = subject.get("name")
+                break
+        if not name:
+            return
+        ednote = ninjs.get("ednote", "")
+        ninjs["ednote"] = f"{name}. {ednote}"
 
     async def _transform_to_ninjs(self, article, subscriber, recursive=True):
         ninjs = await super()._transform_to_ninjs(article, subscriber, recursive)
-        self.update_ninjs_stt_sources(ninjs)
+        self.update_stt_sources(ninjs)
+        self.update_place(ninjs)
+        self.update_subheadline(ninjs)
+        self.update_body_from_content_profiles(ninjs)
+        self.update_sttversion(ninjs)
+        self.update_editorial_note(ninjs)
 
         return ninjs

--- a/server/stt/stt_newsroom_ninjs_formatter.py
+++ b/server/stt/stt_newsroom_ninjs_formatter.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+from superdesk import get_resource_service
 from superdesk.publish.formatters import NewsroomNinjsFormatter
 
 logger = logging.getLogger(__name__)
@@ -39,14 +40,8 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
         except Exception as e:
             logger.error(f"Error occurred when updating stt sources: {str(e)}")
 
-    def update_place(self, ninjs):
-        locators = [place.get("code") for place in ninjs.get("place", [])]
-        if locators:
-            ninjs["locators"] = locators
-
     def update_body_from_content_profiles(self, ninjs):
-        extra = ninjs.get("extra", {})
-        profile = extra.get("content_profile_name", ninjs.get("profile"))
+        profile = ninjs.get("profile")
         if not profile:
             return
         if profile.lower() in ("viiva", "sms"):
@@ -58,10 +53,10 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
     def update_subheadline(self, ninjs):
         extra = ninjs.get("extra", {})
         sttsubheadline = extra.get("sttsubheadline")
-        profile = extra.get("content_profile_name", ninjs.get("profile"))
+        profile = ninjs.get("profile")
         if not sttsubheadline:
             return
-        if profile.lower() in ("pikaplus"):
+        if profile and profile.lower() in ("pikaplus"):
             text = re.sub(r"<[^>]+>", "", sttsubheadline).strip()
             if not text:
                 text = sttsubheadline.strip()
@@ -70,11 +65,21 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
             ninjs["body_html"] = header + (body or "")
 
     def update_sttversion(self, ninjs):
-        extra = ninjs.get("extra", {})
-        profile = extra.get("content_profile_name", ninjs.get("profile"))
+        profile = ninjs.get("profile")
         if not profile:
             return
-        versions = str(profile).strip()
+
+        vocabulary_items = get_resource_service("vocabularies").get_items("sttversion")
+
+        content_profile_name = None
+        for vocab_item in vocabulary_items:
+            if vocab_item.get("name", "").lower() == profile.lower():
+                content_profile_name = vocab_item.get("content_profile_name")
+                break
+
+        versions = str(
+            content_profile_name if content_profile_name is not None else profile
+        ).strip()
         ninjs["sttversion"] = versions
 
     def update_editorial_note(self, ninjs):
@@ -92,7 +97,6 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
         ninjs = await super()._transform_to_ninjs(article, subscriber, recursive)
 
         self.update_stt_sources(ninjs)
-        self.update_place(ninjs)
         self.update_subheadline(ninjs)
         self.update_body_from_content_profiles(ninjs)
         self.update_sttversion(ninjs)

--- a/server/stt/stt_newsroom_ninjs_formatter.py
+++ b/server/stt/stt_newsroom_ninjs_formatter.py
@@ -59,7 +59,7 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
         extra = ninjs.get("extra", {})
         sttsubheadline = extra.get("sttsubheadline")
         profile = extra.get("content_profile_name", ninjs.get("profile"))
-        if not sttsubheadline: 
+        if not sttsubheadline:
             return
         if profile.lower() in ("pikaplus"):
             text = re.sub(r"<[^>]+>", "", sttsubheadline).strip()
@@ -90,6 +90,7 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
 
     async def _transform_to_ninjs(self, article, subscriber, recursive=True):
         ninjs = await super()._transform_to_ninjs(article, subscriber, recursive)
+
         self.update_stt_sources(ninjs)
         self.update_place(ninjs)
         self.update_subheadline(ninjs)

--- a/server/tests/stt_newsroom_ninjs_formatter_test.py
+++ b/server/tests/stt_newsroom_ninjs_formatter_test.py
@@ -5,42 +5,82 @@ from stt.stt_newsroom_ninjs_formatter import STTNewsroomNinjsFormatter
 class STTNewsroomNinjsFormatterTest(TestCase):
     fixture = "stt_newsml_creditline_test.xml"
     add_stt_cvs = True
+    formatter = STTNewsroomNinjsFormatter()
 
-    async def test_source_formatting(self):
-        await self.parse_source_content()
-        subscriber = {
+    def get_subscriber(self):
+        return {
             "_id": "test_subscriber",
             "name": "Test Subscriber",
             "destinations": [{"format": "stt newsroom ninjs"}],
         }
-        formatter = STTNewsroomNinjsFormatter()
-        ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
+
+    async def test_source_formatting(self):
+        await self.parse_source_content()
+        subscriber = self.get_subscriber()
+
+        ninjs = await self.formatter._transform_to_ninjs(self.item, subscriber)
         self.assertEqual(ninjs["source"], "STT-AFP")
 
     async def test_source_formatting_no_sources_fallback(self):
         await self.parse_source_content()
         self.item["subject"] = []
-        subscriber = {
-            "_id": "test_subscriber",
-            "name": "Test Subscriber",
-            "destinations": [{"format": "stt newsroom ninjs"}],
-        }
-        formatter = STTNewsroomNinjsFormatter()
-        ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
+        subscriber = self.get_subscriber()
+
+        ninjs = await self.formatter._transform_to_ninjs(self.item, subscriber)
         self.assertEqual(ninjs["source"], "STT")
 
     async def test_source_formatting_duplicates_handling(self):
+        await self.parse_source_content()
         # ensure duplicates are removed and STT always stays first
         self.item["subject"] = [
             {"name": "STT", "scheme": "sttsource"},
             {"name": "AFP", "scheme": "sttsource"},
             {"name": "AFP", "scheme": "sttsource"},
         ]
-        subscriber = {
-            "_id": "test_subscriber",
-            "name": "Test Subscriber",
-            "destinations": [{"format": "stt newsroom ninjs"}],
-        }
-        formatter = STTNewsroomNinjsFormatter()
-        ninjs = await formatter._transform_to_ninjs(self.item, subscriber)
+        subscriber = self.get_subscriber()
+
+        ninjs = await self.formatter._transform_to_ninjs(self.item, subscriber)
         self.assertEqual(ninjs["source"], "STT-AFP")
+
+    async def test_update_place_sets_locators(self):
+        ninjs = {"place": [{"code": "sttcountry:1"}, {"code": "sttcountry:2"}]}
+        self.formatter.update_place(ninjs)
+        self.assertEqual(ninjs.get("locators"), ["sttcountry:1", "sttcountry:2"])
+
+    async def test_update_body_from_content_profiles(self):
+        ninjs = {
+            "extra": {"content_profile_name": "viiva"},
+            "headline": "Breaking News",
+            "body_html": "",
+        }
+        self.formatter.update_body_from_content_profiles(ninjs)
+        self.assertEqual(ninjs.get("body_html"), "<p>Breaking News</p>")
+
+    async def test_update_subheadline(self):
+        ninjs = {
+            "extra": {
+                "content_profile_name": "pikaplus",
+                "sttsubheadline": "<b>Subtitle</b>",
+            },
+            "body_html": "",
+        }
+        self.formatter.update_subheadline(ninjs)
+        self.assertEqual(ninjs.get("body_html"), "<h2>Subtitle</h2>")
+
+    async def test_update_sttversion_from_profile(self):
+        ninjs = {"extra": {"content_profile_name": "viiva"}}
+        self.formatter.update_sttversion(ninjs)
+        self.assertEqual(ninjs.get("sttversion"), "viiva")
+
+    async def test_update_sttversion_from_profile_fallback(self):
+        ninjs = {"profile": "v3"}
+        self.formatter.update_sttversion(ninjs)
+        self.assertEqual(ninjs.get("sttversion"), "v3")
+
+    async def test_update_editorial_note(self):
+        ninjs = {
+            "subject": [{"scheme": "sttnewsroomnote", "name": "Ei muita versioita"}],
+            "ednote": "Base",
+        }
+        self.formatter.update_editorial_note(ninjs)
+        self.assertEqual(ninjs.get("ednote"), "Ei muita versioita. Base")

--- a/server/tests/stt_newsroom_ninjs_formatter_test.py
+++ b/server/tests/stt_newsroom_ninjs_formatter_test.py
@@ -42,14 +42,9 @@ class STTNewsroomNinjsFormatterTest(TestCase):
         ninjs = await self.formatter._transform_to_ninjs(self.item, subscriber)
         self.assertEqual(ninjs["source"], "STT-AFP")
 
-    async def test_update_place_sets_locators(self):
-        ninjs = {"place": [{"code": "sttcountry:1"}, {"code": "sttcountry:2"}]}
-        self.formatter.update_place(ninjs)
-        self.assertEqual(ninjs.get("locators"), ["sttcountry:1", "sttcountry:2"])
-
     async def test_update_body_from_content_profiles(self):
         ninjs = {
-            "extra": {"content_profile_name": "viiva"},
+            "profile": "viiva",
             "headline": "Breaking News",
             "body_html": "",
         }
@@ -59,23 +54,23 @@ class STTNewsroomNinjsFormatterTest(TestCase):
     async def test_update_subheadline(self):
         ninjs = {
             "extra": {
-                "content_profile_name": "pikaplus",
                 "sttsubheadline": "<b>Subtitle</b>",
             },
+            "profile": "pikaplus",
             "body_html": "",
         }
         self.formatter.update_subheadline(ninjs)
         self.assertEqual(ninjs.get("body_html"), "<h2>Subtitle</h2>")
 
-    async def test_update_sttversion_from_profile(self):
-        ninjs = {"extra": {"content_profile_name": "viiva"}}
+    async def test_update_sttversion_from_cv_match(self):
+        ninjs = {"profile": "Viiva"}
         self.formatter.update_sttversion(ninjs)
         self.assertEqual(ninjs.get("sttversion"), "viiva")
 
-    async def test_update_sttversion_from_profile_fallback(self):
-        ninjs = {"profile": "v3"}
+    async def test_update_sttversion_fallback(self):
+        ninjs = {"profile": "unknown_profile"}
         self.formatter.update_sttversion(ninjs)
-        self.assertEqual(ninjs.get("sttversion"), "v3")
+        self.assertEqual(ninjs.get("sttversion"), "unknown_profile")
 
     async def test_update_editorial_note(self):
         ninjs = {


### PR DESCRIPTION
### Purpose
This PR adjusts the STT Newsroom NINJS output for newshub

### What has changed
- Added function to map place values to locators
- Added function to update body from viiva and sms content profiles
- Added function to update subheadline for pikaplus content profile
- Added function to update sttversion
- Added function to append sttnewsroomnote to ednote
 
###  [STT-1415](https://sofab.atlassian.net/browse/STT-1415)

[STT-1415]: https://sofab.atlassian.net/browse/STT-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ