### PR TITLE
[STT-1421] - Adjust JSON Event output format for Newshub

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -151,6 +151,7 @@ INSTALLED_APPS = [
     "stt.io.feeding_services.stt_http_with_since",
     "stt.io.feeding_services.stt_tt_content_api",
     "stt.io.feed_parsers.stt_tt_parse_content_api",
+    "stt.stt_json_event_formatter",
 ]
 
 MODULES.append("planning")

--- a/server/stt/stt_json_event_formatter.py
+++ b/server/stt/stt_json_event_formatter.py
@@ -1,0 +1,57 @@
+from superdesk import get_resource_service
+from planning.output_formatters import JsonEventFormatter
+
+
+class STTJsonEventFormatter(JsonEventFormatter):
+    name = "STT JSON Event"
+    type = "stt_json_event"
+
+    def __init__(self):
+        super().__init__()
+        self.format_type = "stt_json_event"
+
+    def map_calendar_output(self, item):
+        anpa_category = item.get("anpa_category", [])
+        calendars = []
+
+        if not anpa_category:
+            item["calendars"] = calendars
+            return
+
+        vocabulary_items = get_resource_service("vocabularies").get_items("categories")
+        vocabulary_map = {vocab["qcode"]: vocab for vocab in vocabulary_items}
+
+        for category in anpa_category:
+            vocab = vocabulary_map.get(category["qcode"])
+            if vocab:
+                name = vocab.get("name", "")
+                if name:
+                    calendars.append(
+                        {
+                            "is_active": True,
+                            "qcode": name.lower().replace(" ", ""),
+                            "name": name,
+                        }
+                    )
+
+        has_non_sport = any(
+            vocab.get("name") != "Urheilu"
+            for category in anpa_category
+            if (vocab := vocabulary_map.get(category["qcode"]))
+        )
+        if has_non_sport:
+            calendars.append(
+                {
+                    "is_active": True,
+                    "qcode": "muutkuinurheilu",
+                    "name": "Muut kuin urheilu",
+                }
+            )
+
+        item["calendars"] = calendars
+
+    async def _format_item(self, item, subscribers: list[dict] | None = None):
+        await super()._format_item(item)
+        self.map_calendar_output(item)
+
+        return item

--- a/server/tests/fixtures/json/stt_json_event_item.json
+++ b/server/tests/fixtures/json/stt_json_event_item.json
@@ -1,0 +1,54 @@
+{
+  "_created": "2025-11-03T09:46:43+0000",
+  "_current_version": 1762163208921,
+  "_etag": "c5957e67cabc89d507f96fcb14ff0a92157b9431",
+  "_id": "58475490-83ca-4606-8fb4-fc41fad028b2",
+  "_planning_schedule": [{ "scheduled": "2025-11-03T00:00:00+0000" }],
+  "_time_to_be_confirmed": true,
+  "_updated": "2025-11-03T09:46:48+0000",
+  "actioned_date": null,
+  "anpa_category": [{ "name": "Kotimaa", "qcode": "3", "scheme": null }],
+  "dates": {
+    "all_day": true,
+    "end": "2025-11-03T00:00:00+0000",
+    "start": "2025-11-03T00:00:00+0000",
+    "tz": "Africa/Nairobi"
+  },
+  "definition_short": "Test Definition",
+  "event_contact_info": [],
+  "firstcreated": "2025-11-03T09:46:43+0000",
+  "firstpublished": "2025-11-03T09:46:48+0000",
+  "guid": "58475490-83ca-4606-8fb4-fc41fad028b2",
+  "item_id": "58475490-83ca-4606-8fb4-fc41fad028b2",
+  "language": "fi",
+  "languages": ["fi"],
+  "lock_action": "edit",
+  "lock_session": "69086a875fb7df4eac77495c",
+  "lock_time": "2025-11-03T09:46:43+0000",
+  "lock_user": "6900917d30291cb7d85a783e",
+  "name": "Test Name",
+  "occur_status": {
+    "label": "Tulossa",
+    "name": "Tulossa",
+    "qcode": "eocstat:eos5"
+  },
+  "original_creator": "6900917d30291cb7d85a783e",
+  "place": [],
+  "plans": [],
+  "products": [{ "code": "69086ae15fb7df4eac774961", "name": "All Event" }],
+  "pubstatus": "usable",
+  "registration_details": "vdsvsdv",
+  "state": "scheduled",
+  "state_reason": null,
+  "subject": [
+    { "name": "Mediatilaisuudet", "qcode": "type21", "scheme": "event_type" },
+    {
+      "name": "Ruoka ja juoma",
+      "parent": "20000550",
+      "qcode": "20000568",
+      "scheme": "topics"
+    }
+  ],
+  "type": "event",
+  "versioncreated": "2025-11-03T09:46:48+0000"
+}

--- a/server/tests/stt_json_event_formatter_test.py
+++ b/server/tests/stt_json_event_formatter_test.py
@@ -22,7 +22,7 @@ class STTJsonEventFormatterTest(TestCase):
             formatter.map_calendar_output(item)
 
             calendars = item["calendars"]
-            self.assertGreater(len(calendars), 0)
+            self.assertEqual(len(calendars), 2)
 
             # Should have Muut kuin urheilu for non-sport category
             has_non_sport_category = any(

--- a/server/tests/stt_json_event_formatter_test.py
+++ b/server/tests/stt_json_event_formatter_test.py
@@ -1,0 +1,54 @@
+import json
+import os
+from tests import TestCase
+from stt.stt_json_event_formatter import STTJsonEventFormatter
+
+
+class STTJsonEventFormatterTest(TestCase):
+    add_stt_cvs = True
+    parse_source = False
+    fixture = "json/stt_json_event_item.json"
+
+    def get_sample_item(self):
+        fixture_path = os.path.join(os.path.dirname(__file__), "fixtures", self.fixture)
+        with open(fixture_path, "r") as f:
+            return json.load(f)
+
+    async def test_map_calendar_output_with_categories(self):
+        async with self.app.app_context():
+            formatter = STTJsonEventFormatter()
+            item = self.get_sample_item()
+
+            formatter.map_calendar_output(item)
+
+            calendars = item["calendars"]
+            self.assertGreater(len(calendars), 0)
+
+            # Should have Muut kuin urheilu for non-sport category
+            has_non_sport_category = any(
+                calendar["name"] == "Muut kuin urheilu" for calendar in calendars
+            )
+            self.assertTrue(has_non_sport_category)
+
+    async def test_map_calendar_output_no_categories(self):
+        async with self.app.app_context():
+            formatter = STTJsonEventFormatter()
+            item = self.get_sample_item()
+            item["anpa_category"] = []
+
+            formatter.map_calendar_output(item)
+            self.assertEqual(item["calendars"], [])
+
+    async def test_map_calendar_output_sport_only(self):
+        async with self.app.app_context():
+            formatter = STTJsonEventFormatter()
+            item = self.get_sample_item()
+            item["anpa_category"] = [{"name": "Urheilu", "qcode": "16", "scheme": None}]
+
+            formatter.map_calendar_output(item)
+
+            has_non_sport_category = any(
+                calendar["name"] == "Muut kuin urheilu"
+                for calendar in item["calendars"]
+            )
+            self.assertFalse(has_non_sport_category)


### PR DESCRIPTION
### Purpose
This PR creates a new JSON Event formatter for STT

### What has changed
- Added a new JSON Event formatter with a function to map calendar output from anpa_category
- Added tests
 
###  [STT-1421](https://sofab.atlassian.net/browse/STT-1421)

[STT-1421]: https://sofab.atlassian.net/browse/STT-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ