### PR TITLE
[STT-1415] - Changed sttversion to be saved in subject array to show up in NH

### DIFF
--- a/server/stt/stt_newsroom_ninjs_formatter.py
+++ b/server/stt/stt_newsroom_ninjs_formatter.py
@@ -72,15 +72,29 @@ class STTNewsroomNinjsFormatter(NewsroomNinjsFormatter):
         vocabulary_items = get_resource_service("vocabularies").get_items("sttversion")
 
         content_profile_name = None
+        qcode = None
         for vocab_item in vocabulary_items:
             if vocab_item.get("name", "").lower() == profile.lower():
                 content_profile_name = vocab_item.get("content_profile_name")
+                qcode = vocab_item.get("qcode")
                 break
 
-        versions = str(
+        version = str(
             content_profile_name if content_profile_name is not None else profile
         ).strip()
-        ninjs["sttversion"] = versions
+
+        if qcode and version:
+            if "subject" not in ninjs:
+                ninjs["subject"] = []
+
+            sttversion_exists = any(
+                subj.get("scheme") == "sttversion" for subj in ninjs["subject"]
+            )
+
+            if not sttversion_exists:
+                ninjs["subject"].append(
+                    {"name": version, "scheme": "sttversion", "code": qcode}
+                )
 
     def update_editorial_note(self, ninjs):
         name = None

--- a/server/tests/stt_newsroom_ninjs_formatter_test.py
+++ b/server/tests/stt_newsroom_ninjs_formatter_test.py
@@ -65,12 +65,18 @@ class STTNewsroomNinjsFormatterTest(TestCase):
     async def test_update_sttversion_from_cv_match(self):
         ninjs = {"profile": "Viiva"}
         self.formatter.update_sttversion(ninjs)
-        self.assertEqual(ninjs.get("sttversion"), "viiva")
+        self.assertIn(
+            {"name": "viiva", "scheme": "sttversion", "code": "1"},
+            ninjs.get("subject", []),
+        )
 
     async def test_update_sttversion_fallback(self):
         ninjs = {"profile": "unknown_profile"}
         self.formatter.update_sttversion(ninjs)
-        self.assertEqual(ninjs.get("sttversion"), "unknown_profile")
+        self.assertNotIn(
+            {"name": "unknown_profile", "scheme": "sttversion"},
+            ninjs.get("subject", []),
+        )
 
     async def test_update_editorial_note(self):
         ninjs = {


### PR DESCRIPTION
This PR changes sttversion from a singluar field to being in the `subject` array so as to be picked up on NH and preserve how it worked as explained [in this comment](https://sofab.atlassian.net/browse/STT-1415?focusedCommentId=144199)

[STT-1415](https://sofab.atlassian.net/browse/STT-1415)

[STT-1415]: https://sofab.atlassian.net/browse/STT-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ