### PR TITLE
[STT-1422] - Remove Remove stt prefixed internal fields from primary planning item subject array

### DIFF
--- a/server/stt/stt_json_planning_formatter.py
+++ b/server/stt/stt_json_planning_formatter.py
@@ -6,6 +6,25 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
     name = "STT JSON Planning"
     type = "stt_json_planning"
 
+    STT_PREFIX_INTERNAL_FIELDS = [
+        "sttcheckedby",
+        "sttpicturewhatabout",
+        "sttpicturewhatisphotographed",
+        "sttdoesphotographerknow",
+        "sttpictureregistrationok",
+        "sttregistrationinfo",
+        "sttpicturecategory",
+        "sttpictureheadlinefi",
+        "sttpicturecaptionfi",
+        "sttpictureinstructionsfi",
+        "sttpicturekeywordsfi",
+        "sttpictureheadlineen",
+        "sttpicturecaptionen",
+        "sttpictureinstructionsen",
+        "sttpicturekeywordsen",
+        "sttpictureinvoiced",
+    ]
+
     CATEGORY_QCODE_NHUB_MAP = {
         "3": {
             "name": "Kotimaa",
@@ -85,11 +104,13 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
     def exclude_internal_planning_fields(self, item):
         if "internal_note" in item:
             del item["internal_note"]
+
         if "subject" in item:
+            exclude_fields = self.STT_PREFIX_INTERNAL_FIELDS
             item["subject"] = [
                 subject
                 for subject in item["subject"]
-                if subject.get("scheme") != "sttcheckedby"
+                if subject.get("scheme") not in exclude_fields
             ]
 
     def exclude_internal_coverage_fields(self, item):
@@ -99,23 +120,8 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
         exclude_fields = [
             "headline",
             "location",
-            "sttpicturewhatabout",
-            "sttpicturewhatisphotographed",
             "internal_note",
-            "sttdoesphotographerknow",
-            "sttpictureregistrationok",
-            "sttregistrationinfo",
-            "sttpicturecategory",
-            "sttpictureheadlinefi",
-            "sttpicturecaptionfi",
-            "sttpictureinstructionsfi",
-            "sttpicturekeywordsfi",
-            "sttpictureheadlineen",
-            "sttpicturecaptionen",
-            "sttpictureinstructionsen",
-            "sttpicturekeywordsen",
-            "sttpictureinvoiced",
-        ]
+        ] + self.STT_PREFIX_INTERNAL_FIELDS
 
         for coverage in item["coverages"]:
             planning = coverage.get("planning")

--- a/server/stt/stt_json_planning_formatter.py
+++ b/server/stt/stt_json_planning_formatter.py
@@ -135,6 +135,14 @@ class STTJsonPlanningFormatter(JsonPlanningFormatter):
                     if field.get("field") not in exclude_fields
                 ]
 
+            # Then filter out internal fields from the subjects array
+            if "subject" in planning:
+                planning["subject"] = [
+                    field
+                    for field in planning["subject"]
+                    if field.get("scheme") not in exclude_fields
+                ]
+
     def map_agenda_output(self, item):
         anpa_category = item.get("anpa_category", [])
         agendas = []

--- a/server/tests/fixtures/json/stt_json_planning_item.json
+++ b/server/tests/fixtures/json/stt_json_planning_item.json
@@ -103,9 +103,7 @@
             "address": {
               "city": "Test City",
               "country": "Test Country",
-              "line": [
-                "Test Address"
-              ]
+              "line": ["Test Address"]
             },
             "details": "Test Details",
             "name": "Test Location",
@@ -163,9 +161,7 @@
   "item_class": "plinat:newscoverage",
   "item_id": "f2158efe-aaec-4e77-8ea3-5c9b53f218eb",
   "language": "fi",
-  "languages": [
-    "fi"
-  ],
+  "languages": ["fi"],
   "lock_action": "edit",
   "lock_session": "69009183985c980a84842847",
   "lock_time": "2025-10-28T10:13:32+0000",
@@ -200,6 +196,16 @@
       "name": "Pääaihe (3 300)",
       "qcode": "stturgency-1",
       "scheme": "stturgency"
+    },
+    {
+      "name": "Ei",
+      "qcode": "no",
+      "scheme": "sttdoesphotographerknow"
+    },
+    {
+      "name": "ACE taide viihde kulttuuri",
+      "qcode": "ACE",
+      "scheme": "sttpicturecategory"
     }
   ],
   "type": "planning",

--- a/server/tests/stt_json_planning_formatter_test.py
+++ b/server/tests/stt_json_planning_formatter_test.py
@@ -49,6 +49,12 @@ class STTJsonPlanningFormatterTest(TestCase):
                     for subj in item.get("subject", [])
                 )
             )
+            self.assertTrue(
+                any(
+                    subj.get("scheme") == "sttdoesphotographerknow"
+                    for subj in item.get("subject", [])
+                )
+            )
 
             formatter.exclude_internal_planning_fields(item)
 
@@ -56,6 +62,12 @@ class STTJsonPlanningFormatterTest(TestCase):
             self.assertFalse(
                 any(
                     subj.get("scheme") == "sttcheckedby"
+                    for subj in item.get("subject", [])
+                )
+            )
+            self.assertFalse(
+                any(
+                    subj.get("scheme") == "sttdoesphotographerknow"
                     for subj in item.get("subject", [])
                 )
             )

--- a/server/tests/stt_json_planning_formatter_test.py
+++ b/server/tests/stt_json_planning_formatter_test.py
@@ -78,11 +78,23 @@ class STTJsonPlanningFormatterTest(TestCase):
             self.assertIn("internal_note", planning)
             self.assertIn("scheduled", planning)
             fields = planning["fields"]
+            subjects = planning["subject"]
             self.assertTrue(
                 any(field["field"] == "sttpicturewhatabout" for field in fields)
             )
             self.assertTrue(
                 any(field["field"] == "sttregistrationinfo" for field in fields)
+            )
+            self.assertTrue(
+                any(
+                    subj.get("scheme") == "sttdoesphotographerknow" for subj in subjects
+                )
+            )
+            self.assertTrue(
+                any(
+                    subj.get("scheme") == "sttpictureregistrationok"
+                    for subj in subjects
+                )
             )
 
             formatter.exclude_internal_coverage_fields(item)
@@ -92,11 +104,24 @@ class STTJsonPlanningFormatterTest(TestCase):
             self.assertNotIn("internal_note", planning)
             self.assertIn("scheduled", planning)
             fields_after = planning["fields"]
+            subjects_after = planning["subject"]
             self.assertFalse(
                 any(field["field"] == "sttpicturewhatabout" for field in fields_after)
             )
             self.assertFalse(
                 any(field["field"] == "sttregistrationinfo" for field in fields_after)
+            )
+            self.assertFalse(
+                any(
+                    subj.get("scheme") == "sttdoesphotographerknow"
+                    for subj in subjects_after
+                )
+            )
+            self.assertFalse(
+                any(
+                    subj.get("scheme") == "sttpictureregistrationok"
+                    for subj in subjects_after
+                )
             )
 
     async def test_map_agendas(self):

--- a/server/tests/stt_json_planning_formatter_test.py
+++ b/server/tests/stt_json_planning_formatter_test.py
@@ -87,13 +87,14 @@ class STTJsonPlanningFormatterTest(TestCase):
             )
             self.assertTrue(
                 any(
-                    subj.get("scheme") == "sttdoesphotographerknow" for subj in subjects
+                    subject.get("scheme") == "sttdoesphotographerknow"
+                    for subject in subjects
                 )
             )
             self.assertTrue(
                 any(
-                    subj.get("scheme") == "sttpictureregistrationok"
-                    for subj in subjects
+                    subject.get("scheme") == "sttpictureregistrationok"
+                    for subject in subjects
                 )
             )
 
@@ -113,14 +114,14 @@ class STTJsonPlanningFormatterTest(TestCase):
             )
             self.assertFalse(
                 any(
-                    subj.get("scheme") == "sttdoesphotographerknow"
-                    for subj in subjects_after
+                    subject.get("scheme") == "sttdoesphotographerknow"
+                    for subject in subjects_after
                 )
             )
             self.assertFalse(
                 any(
-                    subj.get("scheme") == "sttpictureregistrationok"
-                    for subj in subjects_after
+                    subject.get("scheme") == "sttpictureregistrationok"
+                    for subject in subjects_after
                 )
             )
 


### PR DESCRIPTION
This PR adds logic to remove the stt prefixed internal fields from the primary planning item too. Previously the fields were stripped in the `coverages.planning` items only.

[STT-1422](https://sofab.atlassian.net/browse/STT-1422)

[STT-1422]: https://sofab.atlassian.net/browse/STT-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ