### PR TITLE
Feature/report template logic tweaks

### DIFF
--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -425,7 +425,7 @@ def _set_stt_fields(
     for ag in agendas or []:
         new_items: List[Dict[str, Any]] = []
         for pl in ag.get("items") or []:
-            # get news_coverage_status for planning item, note that for 'kuva' item_type the returned value is different
+            # get news_coverage_status for planning item
             news_coverage_status = _get_planning_coverages_metadata(pl, item_type)
             if item_type == "teksti" and not news_coverage_status:
                 continue  # exclude items without news_coverage_status for 'teksti' items
@@ -435,6 +435,10 @@ def _set_stt_fields(
                 pl, "kuva", imagetypes=True
             )
             pl["sttimagetypes"] = item_imagetypes.get("imagetypes") or []
+            if item_type == "kuva":
+                # if this is an "kuvalupaus" and sttimagetypes is empty, exclude the item
+                if not pl["sttimagetypes"]:
+                    continue
             # get sttpicturewhatabouts for planning item
             item_sttpicturewhatabouts = _get_planning_coverages_metadata(
                 pl, item_type, sttpicturewhatabout=True
@@ -442,10 +446,6 @@ def _set_stt_fields(
             pl["sttpicturewhatabouts"] = (
                 item_sttpicturewhatabouts.get("sttpicturewhatabout") or []
             )
-            if item_type == "kuva":
-                # if this is an "kuvalupaus" and sttimagetypes is empty, exclude the item
-                if not pl["sttimagetypes"]:
-                    continue
             # try to get latest published item with sttnewsroomnote subject
             published_related_items = (
                 get_published_items_with_sttnewsroomnote_by_planning_id(pl.get("_id"))

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -347,8 +347,17 @@ def _set_priority_fields(pl: Dict[str, Any], item_type: str) -> None:
     # if item_type is "teksti" ("basic" lupaus) and priority is "Vain tulokset", do not set the fields (so the item gets excluded)
     if item_type == "teksti" and priority == "Vain tulokset":
         return
+    sort_value = -1
+    if isinstance(priority_numeric, str):
+        numeric_str = priority_numeric.replace(" ", "")
+        if numeric_str.isdigit():
+            sort_value = int(numeric_str)
+    elif isinstance(priority_numeric, (int, float)):
+        sort_value = int(priority_numeric)
     pl["stt_priority"] = priority
     pl["stt_priority_numeric"] = priority_numeric
+    # add also a sortable numeric field
+    pl["stt_priority_numeric_sort"] = sort_value
 
 
 def _get_latest_published_item(
@@ -499,12 +508,9 @@ def _get_items_with_highest_priority(
     highest_priority = 3300
     main_topic_items = []
     for pl in ag.get("items") or []:
-        try:
-            priority_numeric = int(pl.get("stt_priority_numeric", "0"))
-            if priority_numeric == highest_priority:
-                main_topic_items.append(pl)
-        except ValueError:
-            continue
+        sort_value = pl.get("stt_priority_numeric_sort")
+        if sort_value == highest_priority:
+            main_topic_items.append(pl)
     return main_topic_items
 
 

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Dict, List, Any, Set
 import logging
 
@@ -400,10 +401,25 @@ def _set_stt_fields(
     item_type: str,
 ) -> List[Dict[str, Any]]:
     """
-    Sets stt_priority and stt_priority_numeric fields on each planning item.
-    Filters out items without a valid stt_priority.
-    If events is empty, sets related_events_expanded to [].
-    Expands related_events to related_events_expanded using by_key mapping.
+    Enrich agendas with the metadata required by the Lupaus/Kuva exports.
+
+    For each planning item the function:
+    - attaches coverage metadata (``news_coverage_status``, ``sttimagetypes``,
+        ``sttpicturewhatabouts``) and the latest published item when available
+    - skips items that lack the coverage information or priority expected for
+        the given ``item_type``
+    - sets ``stt_priority``, ``stt_priority_numeric`` and
+        ``stt_priority_numeric_sort``
+        - expands related events into a chronologically sorted
+            ``related_events_expanded`` when event lookups are supplied
+
+    After processing, each agenda contains:
+    - ``grouped_items``: mapping planning dates to categories and their items
+    - ``has_multiple_dates``: flag indicating several planning dates are present
+    - ``main_topic_items``: items whose priority numeric equals the highest
+        configured value (3300)
+
+    Returns the filtered/enriched agendas list.
     """
 
     for ag in agendas or []:
@@ -445,60 +461,164 @@ def _set_stt_fields(
                 pl["related_events_expanded"] = []
                 new_items.append(pl)
                 continue
-            # Expand related events
+            # Expand related events and sort by start date (with fallback to end)
             expanded: List[Dict[str, Any]] = []
             for rel_event in pl.get("related_events") or []:
                 key = rel_event.get("_id")
                 ev = by_key.get(str(key)) if key else None
                 if ev:
                     expanded.append(ev)
+            expanded.sort(
+                key=lambda e: e.get("dates", {}).get("start")
+                or e.get("dates", {}).get("end")
+                or ""
+            )
             pl["related_events_expanded"] = expanded
             new_items.append(pl)
         ag["items"] = new_items
-        # group agenda items by category
-        grouped_agendas = _group_agenda_items_by_category(ag)
+        # group agenda items
+        grouped_agendas = _group_agenda_items(ag, item_type)
+        ag["has_multiple_dates"] = len(grouped_agendas) > 1
         # and attach to agenda
         ag["grouped_items"] = grouped_agendas
-        # get main topic items (highest priority)
-        main_topic_items = _get_items_with_highest_priority(ag)
-        ag["main_topic_items"] = main_topic_items
     return agendas
 
 
-def _group_agenda_items_by_category(
+def _group_agenda_items_by_planning_date(
     ag: Dict[str, Any],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
-    Groups agenda items by their category.
+    Groups agenda items by their planning date.
 
     Args:
         agendas: A list of agenda dictionaries. Each agenda may include an "items"
-            list; each item may include a "categories" field.
+            list; each item may include a "planning_date" field.
 
     Returns:
-        A dictionary where keys are categories and values are lists of agenda items
-        belonging to those categories. Items without a category are grouped under
-        the key 'Uncategorized'.
+        A dictionary where keys are planning dates and values are lists of agenda items
+        belonging to those planning dates. Items without a planning date are grouped under
+        the key 'Undated'.
     """
-    categorized_items: Dict[str, List[Dict[str, Any]]] = {}
+    dated_items: Dict[str, List[Dict[str, Any]]] = {}
     for pl in ag.get("items") or []:
-        category_name = get_category_from_agenda_item(pl) or "Uncategorized"
-        if category_name not in categorized_items:
-            categorized_items[category_name] = []
-        categorized_items[category_name].append(pl)
-    # sort categories like: Kotimaa, Politiikka, Talous, Kulttuuri, Ulkomaat, Urheilu
-    sorted_categories = [
-        "Kotimaa",
-        "Politiikka",
-        "Talous",
-        "Kulttuuri",
-        "Ulkomaat",
-        "Urheilu",
-    ]
-    categorized_items = {
-        k: categorized_items[k] for k in sorted_categories if k in categorized_items
+        planning_date_value = pl.get("planning_date")
+        planning_date = "Undated"
+
+        if isinstance(planning_date_value, datetime.datetime):
+            planning_date = planning_date_value.date().isoformat()
+        elif isinstance(planning_date_value, datetime.date):
+            planning_date = planning_date_value.isoformat()
+        elif isinstance(planning_date_value, str):
+            planning_date = planning_date_value
+            if "T" in planning_date:
+                planning_date = planning_date.split("T")[0]
+        # tolerate falsy values after normalization
+        if not planning_date:
+            planning_date = "Undated"
+        if planning_date not in dated_items:
+            dated_items[planning_date] = []
+        dated_items[planning_date].append(pl)
+    return dated_items
+
+
+def _select_main_topic_items_for_date(
+    date_items: List[Dict[str, Any]],
+    main_topic_items: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return main-topic items that belong to the supplied date bucket.
+
+    Falls back to comparing ``_id`` values in case the objects referenced by
+    ``main_topic_items`` differ from the entries stored in ``date_items``.
+    """
+
+    if not main_topic_items or not date_items:
+        return []
+
+    selected: List[Dict[str, Any]] = []
+    date_item_ids = {
+        item.get("_id")
+        for item in date_items
+        if isinstance(item, dict) and item.get("_id")
     }
-    return categorized_items
+
+    for candidate in main_topic_items:
+        if candidate in date_items:
+            selected.append(candidate)
+            continue
+        candidate_id = candidate.get("_id") if isinstance(candidate, dict) else None
+        if candidate_id and candidate_id in date_item_ids:
+            selected.append(candidate)
+
+    return selected
+
+
+def _group_agenda_items(
+    ag: Dict[str, Any], item_type: str
+) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+    """
+    Groups agenda items first by planning date and then by category.
+    Add main_topic_items key for highest-priority items for each date if item_type is "teksti".
+
+    Args:
+        ag: A single agenda dictionary that already contains an "items" list.
+
+    Returns:
+        A nested dictionary of the form ``{date: {"Kotimaa": [items...]}, "Politiikka": [items...]}, main_topic_items: [items...]}``. Items without a
+        category are grouped under the key ``"Uncategorized"`` inside their respective date.
+    """
+    main_topic_items = _get_items_with_highest_priority(ag)
+    grouped_by_date: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+    for date, items in _group_agenda_items_by_planning_date(ag).items():
+        logger.info(f"Grouping agenda items for date: {date}")
+        categories_for_date: Dict[str, List[Dict[str, Any]]] = {}
+        # Add main_topic_items key if item_type is "teksti" (kuvalupaus does not have main topics)
+        if item_type == "teksti":
+            # Check if the highest-priority items fall into this date bucket.
+            main_topic_items_for_date = _select_main_topic_items_for_date(
+                items, main_topic_items
+            )
+            if main_topic_items_for_date:
+                categories_for_date["main_topic_items"] = main_topic_items_for_date
+        for pl in items:
+            category_name = get_category_from_agenda_item(pl) or "Uncategorized"
+            categories_for_date.setdefault(category_name, []).append(pl)
+
+        # Preferred category ordering
+        preferred_order = [
+            "Kotimaa",
+            "Politiikka",
+            "Talous",
+            "Kulttuuri",
+            "Ulkomaat",
+            "Urheilu",
+        ]
+        ordered_categories: Dict[str, List[Dict[str, Any]]] = {}
+        remaining = dict(categories_for_date)
+        if "main_topic_items" in remaining:
+            ordered_categories["main_topic_items"] = remaining.pop("main_topic_items")
+        for category in preferred_order:
+            if category in remaining:
+                ordered_categories[category] = remaining.pop(category)
+        for category in sorted(remaining.keys()):
+            ordered_categories[category] = remaining[category]
+
+        grouped_by_date[date] = ordered_categories
+    # sort dates chronologically
+
+    def _sort_key(key: str) -> datetime.datetime:
+        try:
+            return datetime.datetime.fromisoformat(key)
+        except (ValueError, TypeError):
+            # place undated entries at the end while keeping sort stable
+            return datetime.datetime.max
+
+    grouped_by_date = dict(
+        sorted(
+            grouped_by_date.items(),
+            key=lambda item: _sort_key(item[0]),
+        )
+    )
+    return grouped_by_date
 
 
 def _get_items_with_highest_priority(
@@ -518,17 +638,24 @@ def enrich_planning_agendas(
     agendas: List[Dict[str, Any]], item_type: str
 ) -> List[Dict[str, Any]]:
     """
-    Adds item.related_events_expanded = [event, ...]
-    Each event has at least: _id, name, dates, location (resolved if IDs).
-    Also adds item.stt_priority and item.stt_priority_numeric fields.
+    Enrich every planning agenda with the data required by the Lupaus exports.
+
+    The function:
+    - drops draft agenda items
+    - looks up related events in bulk (when IDs are present)
+    - delegates to :func:`_set_stt_fields` to attach coverage metadata, priorities,
+      chronologically sorted ``related_events_expanded`` values, grouped items,
+      and main-topic selections
+
     Args:
-        agendas: A list of agenda dictionaries. Each agenda may include an "items"
-            list; each item may include a "related_events" list of mappings.
-        item_type: The type of the planning item, 'teksti' / 'kuva'.
+        agendas: Source agendas that may contain ``items`` and related event
+            references.
+        item_type: The Lupaus flavour (``"teksti"`` or ``"kuva"``) which
+            influences filtering rules.
+
     Returns:
-        The input list of agendas, with each planning item enriched with
-        'related_events_expanded', 'stt_priority', and 'stt_priority_numeric' fields.
-        Items without a valid 'stt_priority' are excluded from the agendas.
+        The same agenda list with each entry enriched in-place. Items that do
+        not meet the Lupaus requirements are filtered out of their agendas.
     """
     for ag in agendas:
         # Exclude draft items
@@ -566,14 +693,5 @@ def enrich_planning_agendas(
             by_key[str(e["_id"])] = e
     # Attach to each planning item
     _set_stt_fields(agendas, by_key, events, item_type)
-
-    # Sort related_events_expanded by start date
-    for ag in agendas or []:
-        for pl in ag.get("items") or []:
-            pl["related_events_expanded"].sort(
-                key=lambda e: e.get("dates", {}).get("start")
-                or e.get("dates", {}).get("end")
-                or ""
-            )
 
     return agendas

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -55,6 +55,7 @@ def _get_planning_coverages_metadata(
     pl: Dict[str, Any],
     item_type: str,
     imagetypes: bool = False,
+    sttpicturewhatabout: bool = False,
 ) -> Dict[str, Any]:
     """Return coverage metadata for a planning item, fetching from Mongo if needed.
 
@@ -63,6 +64,8 @@ def _get_planning_coverages_metadata(
     coverages. When ``imagetypes`` is ``True`` the function instead collects all
     ``sttimagetype`` subject ``name`` values from the coverages and returns them as
     ``{"imagetypes": [...]}``.
+    If ``sttpicturewhatabout`` is ``True``, the function returns the values from the
+    ``sttpicturewhatabout`` fields from coverages planning fields.
 
     The function first inspects the in-memory planning item and only falls back to a
     Mongo query when the desired information is missing locally.
@@ -74,42 +77,84 @@ def _get_planning_coverages_metadata(
     coverages = [cov for cov in pl.get("coverages") or [] if isinstance(cov, dict)]
 
     imagetypes_local: List[str] = []
-    if imagetypes:
+    sttpicturewhatabouts_local: List[str] = []
+
+    if sttpicturewhatabout:
+        sttpicturewhatabouts_local = _get_sttpicturewhatabouts_from_coverages(coverages)
+        if sttpicturewhatabouts_local:
+            return {"sttpicturewhatabout": sttpicturewhatabouts_local}
+
+    elif imagetypes:
         imagetypes_local = _collect_imagetypes_from_coverages(coverages)
         if imagetypes_local:
             return {"imagetypes": imagetypes_local}
-    else:
-        status = _extract_news_coverage_status(coverages)
+    elif not imagetypes and not sttpicturewhatabout:
+        status = _extract_news_coverage_status(coverages, item_type)
         if status:
             return status
 
     pl_id = pl.get("_id")
     if not pl_id:
-        return {"imagetypes": imagetypes_local} if imagetypes else {}
+        if sttpicturewhatabout:
+            return (
+                {"sttpicturewhatabout": sttpicturewhatabouts_local}
+                if sttpicturewhatabouts_local
+                else {}
+            )
+        elif imagetypes:
+            return {"imagetypes": imagetypes_local} if imagetypes_local else {}
+        return {}
 
     coverages_from_db = _load_coverages_from_mongo(pl_id, item_type)
     if not coverages_from_db:
         return {"imagetypes": imagetypes_local} if imagetypes else {}
 
+    if sttpicturewhatabout:
+        sttpicturewhatabouts_db = _get_sttpicturewhatabouts_from_coverages(
+            coverages_from_db
+        )
+        return {"sttpicturewhatabout": sttpicturewhatabouts_db}
     if imagetypes:
         image_coverage_types = _collect_imagetypes_from_coverages(coverages_from_db)
         return {"imagetypes": image_coverage_types}
 
-    return _extract_news_coverage_status(coverages_from_db)
+    return _extract_news_coverage_status(coverages_from_db, item_type)
 
 
-def _extract_news_coverage_status(coverages: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Return the first non-empty ``news_coverage_status`` mapping from coverages."""
+def _extract_news_coverage_status(
+    coverages: List[Dict[str, Any]], item_type: str
+) -> Dict[str, Any]:
+    """
+    Return the first non-empty ``news_coverage_status`` mapping from coverages.
+    Double check that g2_content_type matches item_type => 'teksti' == 'text'.
+    With 'kuva' (kuvalupaus) it does not matter because we include only items with "Tehdään" ("ncostat:int") status.
+    """
 
     for cov in coverages:
         status = cov.get("news_coverage_status")
+        planning = cov.get("planning")
+        if planning and isinstance(planning, dict):
+            g2_content_type = planning.get("g2_content_type")
+            if item_type == "teksti" and g2_content_type != "text":
+                continue
         if status:
+            """status is a dict like:
+                {
+                "label": "Ehkä",
+                "name": "coverage not decided yet",
+                "qcode": "ncostat:notdec"
+            }"""
             return status
     return {}
 
 
-def _collect_imagetypes_from_coverages(coverages: List[Dict[str, Any]]) -> List[str]:
-    """Collect unique ``sttimagetype`` subject names from coverage planning data."""
+def _collect_imagetypes_from_coverages(
+    coverages: List[Dict[str, Any]],
+) -> List[str]:
+    """
+    Collect unique ``sttimagetype`` subject names from coverage planning data.
+    Exclude if news_coverage_status qcode is not "ncostat:int"
+    """
 
     seen: Set[str] = set()
     imagetypes: List[str] = []
@@ -120,6 +165,10 @@ def _collect_imagetypes_from_coverages(coverages: List[Dict[str, Any]]) -> List[
         subjects = planning.get("subject")
         if not isinstance(subjects, list):
             continue
+        status = cov.get("news_coverage_status")
+        # exclude if news_coverage_status qcode is not "ncostat:int" ("Tehdään")
+        if status and status.get("qcode") != "ncostat:int":
+            continue
         for sub in subjects:
             if not isinstance(sub, dict) or sub.get("scheme") != "sttimagetype":
                 continue
@@ -128,6 +177,23 @@ def _collect_imagetypes_from_coverages(coverages: List[Dict[str, Any]]) -> List[
                 seen.add(name)
                 imagetypes.append(name)
     return imagetypes
+
+
+def _get_sttpicturewhatabouts_from_coverages(
+    coverages: List[Dict[str, Any]],
+) -> List[str]:
+    """sttpicturewhatabout is stored in coverage.planning.fields with field "sttpicturewhatabout" => get the value field value"""
+    sttpicturewhatabouts: List[str] = []
+    for cov in coverages:
+        planning = cov.get("planning")
+        if not isinstance(planning, dict):
+            continue
+        fields = planning.get("fields", [])
+        for field in fields:
+            field_name = field.get("field")
+            if field_name == "sttpicturewhatabout" and field.get("value"):
+                sttpicturewhatabouts.append(field.get("value", ""))
+    return sttpicturewhatabouts
 
 
 def _load_coverages_from_mongo(pl_id: str, item_type: str) -> List[Dict[str, Any]]:
@@ -188,11 +254,11 @@ def get_priority_from_agenda_item(item: Dict[str, Any]) -> str:
         numeric_priority = item.get("priority", "")
         # if numeric_priority is > 0, return customized priority with synthetic 'name'-field
         if numeric_priority and numeric_priority > 0:
-            # 1 = Pääaihe (3300), 2 = Perus (2000), 3 = Perus+ (2700), 4 = Lyhyt (800), 5 = Vain tulokset
+            # 1 = Pääaihe (3300), 2 = Perus+ (2700), 3 = Perus (2000), 4 = Lyhyt (800), 5 = Vain tulokset, 6 = Vain tsekkaus
             priority_map = {
                 1: "Pääaihe (3 300)",
-                2: "Perus (2 000)",
-                3: "Perus+ (2 700)",
+                2: "Perus+ (2 700)",
+                3: "Perus (2 000)",
                 4: "Lyhyt (800)",
                 5: "Vain tulokset",
                 6: "Vain tsekkaus",
@@ -271,10 +337,16 @@ def get_numeric_value_from_priority(priority: str) -> str:
         return ""
 
 
-def _set_priority_fields(pl: Dict[str, Any]) -> None:
+def _set_priority_fields(pl: Dict[str, Any], item_type: str) -> None:
     """Compute and set priority fields on a planning item in a single place."""
     priority = get_priority_from_agenda_item(pl)
     priority_numeric = get_numeric_value_from_priority(priority)
+    # if priority is "Vain tsekkaus", do not set the fields (so the item gets excluded)
+    if priority == "Vain tsekkaus":
+        return
+    # if item_type is "teksti" ("basic" lupaus) and priority is "Vain tulokset", do not set the fields (so the item gets excluded)
+    if item_type == "teksti" and priority == "Vain tulokset":
+        return
     pl["stt_priority"] = priority
     pl["stt_priority_numeric"] = priority_numeric
 
@@ -292,13 +364,13 @@ def _get_latest_published_item(
     """
     if not published_items:
         return {}
-    # first filter out items that do not have subject with scheme 'sttnewsroomnote' and qcode "nootherversions", "printformat" or "validforprint"
+    # first filter out items that do not have subject with scheme 'sttnewsroomnote' and qcode "nootherversions" or "printformat"
     filtered_items = [
         item
         for item in published_items
         if any(
             sub.get("scheme") == "sttnewsroomnote"
-            and sub.get("qcode") in ["nootherversions", "printformat", "validforprint"]
+            and sub.get("qcode") in ["nootherversions", "printformat"]
             for sub in item.get("subject", [])
         )
     ]
@@ -328,14 +400,27 @@ def _set_stt_fields(
     for ag in agendas or []:
         new_items: List[Dict[str, Any]] = []
         for pl in ag.get("items") or []:
-            # get news_coverage_status for planning item
+            # get news_coverage_status for planning item, note that for 'kuva' item_type the returned value is different
             news_coverage_status = _get_planning_coverages_metadata(pl, item_type)
+            if item_type == "teksti" and not news_coverage_status:
+                continue  # exclude items without news_coverage_status for 'teksti' items
             pl["news_coverage_status"] = news_coverage_status
-            # get sttimagetypes for planning item (always use "kuva" as item_type to get image types)
+            # get sttimagetypes for planning item (always use "kuva" as item_type to get image types from coverages)
             item_imagetypes = _get_planning_coverages_metadata(
                 pl, "kuva", imagetypes=True
             )
             pl["sttimagetypes"] = item_imagetypes.get("imagetypes") or []
+            # get sttpicturewhatabouts for planning item
+            item_sttpicturewhatabouts = _get_planning_coverages_metadata(
+                pl, item_type, sttpicturewhatabout=True
+            )
+            pl["sttpicturewhatabouts"] = (
+                item_sttpicturewhatabouts.get("sttpicturewhatabout") or []
+            )
+            if item_type == "kuva":
+                # if this is an "kuvalupaus" and sttimagetypes is empty, exclude the item
+                if not pl["sttimagetypes"]:
+                    continue
             # try to get latest published item with sttnewsroomnote subject
             published_related_items = (
                 get_published_items_with_sttnewsroomnote_by_planning_id(pl.get("_id"))
@@ -343,7 +428,7 @@ def _set_stt_fields(
             latest_published_item = _get_latest_published_item(published_related_items)
             # attach latest published item to planning item
             pl["latest_published_item"] = latest_published_item
-            _set_priority_fields(pl)
+            _set_priority_fields(pl, item_type)
             if not pl.get("stt_priority"):
                 continue  # exclude items without priority
             # if events is empty list, related_events_expanded will be empty

--- a/server/stt/template_filters/__init__.py
+++ b/server/stt/template_filters/__init__.py
@@ -39,11 +39,14 @@ def _to_helsinki(value):
         return None  # graceful fallback
 
 
-def fi_date(value: str) -> str:
+def fi_date(value: str, capitalized: bool = False) -> str:
     dt = _to_helsinki(value)
     if not dt:
         return value or ""
-    return f"{_WEEKDAY_FI[dt.weekday()]} {dt.day}.{dt.month}."
+    weekday = _WEEKDAY_FI[dt.weekday()]
+    if capitalized:
+        weekday = weekday.capitalize()
+    return f"{weekday} {dt.day}.{dt.month}."
 
 
 def fi_current_date() -> str:

--- a/server/templates/kuvalupaus_events_template.html
+++ b/server/templates/kuvalupaus_events_template.html
@@ -21,34 +21,26 @@
 
 {# Macro to render a single planning item paragraph (reused for grouped & ungrouped) #}
 {% macro render_planning_item(item) -%}
-  {%- set bits = [] -%}
-  {%- if item.slugline %}{% set _ = bits.append(item.slugline) %}{% endif -%}
+  {%- set first_parts = [] -%}
+  {%- if item.slugline %}{% set _ = first_parts.append(item.slugline) %}{% endif -%}
+  {# Add image types and picturewhatabouts to separate list so we can combine them later #}
+  {%- set second_parts = [] -%}
   {# Add coverages if available #}
   {%- if item.sttimagetypes -%}
     {%- set cov_list = item.sttimagetypes if item.sttimagetypes is iterable else [item.sttimagetypes] -%}
     {%- if cov_list | length > 0 -%}
-      {%- set _ = bits.append((cov_list | join(', '))) -%}
+      {%- set _ = second_parts.append((cov_list | join(', '))) -%}
     {%- endif -%}
-  {%- endif -%}
-  {%- if bits %}<p>{{- bits | join('. ') -}}.</p>{% endif -%}
-{%- endmacro %}
-
-{# Macro to render a single main topic item paragraph #}
-{% macro render_main_topic_item(item) -%}
-  {%- set bits = [] -%}
-    {%- if item.slugline -%}
-      {%- set slug = item.slugline | trim -%}
-      {%- if slug.endswith('?') -%}
-        {% set _ = bits.append(slug) %}
-      {%- else -%}
-        {% set _ = bits.append(slug ~ '.') %}
+    {%- if item.sttpicturewhatabouts -%}
+      {%- set whatabout_list = item.sttpicturewhatabouts if item.sttpicturewhatabouts is iterable else [item.sttpicturewhatabouts] -%}
+      {%- if whatabout_list | length > 0 -%}
+        {%- set _ = second_parts.append(whatabout_list | join(', ')) -%}
       {%- endif -%}
     {%- endif -%}
-  {%- set category_str = render_planning_item_category(item) -%}
-  {%- if category_str %}
-    {% set _ = bits.append(category_str) %}
   {%- endif -%}
-  {%- if bits %}<p>{{- bits | join(' ') -}}</p>{% endif -%}
+  {%- if first_parts %}
+    <p>{{- first_parts | join('. ') -}}. {% if second_parts %} {{ second_parts | join(', ') }}.{% endif %}</p>
+  {%- endif -%}
 {%- endmacro %}
 
 {# One paragraph per agenda item; grouped by category if grouped_items present #}
@@ -57,36 +49,9 @@
   {%- if grouped and grouped.items() | count > 0 -%}
     {%- for category, items in grouped.items() -%}
       <h2>{{ category | upper }}</h2>
-      {%- set coverage = namespace(intended=[], undecided=[], other=[]) -%}
       {%- for item in items -%}
-        {%- set status = item.news_coverage_status or {} -%}
-        {%- set status_name = (status.name or '') | lower -%}
-        {%- if status_name == 'coverage intended' -%}
-          {%- set _ = coverage.intended.append(item) -%}
-        {%- elif status_name == 'coverage not decided yet' -%}
-          {%- set _ = coverage.undecided.append(item) -%}
-        {%- else -%}
-          {%- set _ = coverage.other.append(item) -%}
-        {%- endif -%}
-      {%- endfor -%}
-
-      {%- for item in coverage.intended -%}
         {{ render_planning_item(item) }}
       {%- endfor -%}
-
-      {%- if coverage.undecided -%}
-        <h2>JOS AIHETTA</h2>
-        {%- for item in coverage.undecided -%}
-          {{ render_planning_item(item) }}
-        {%- endfor -%}
-      {%- endif -%}
-
-      {%- if coverage.other -%}
-        <h2>EI</h2>
-        {%- for item in coverage.other -%}
-          {{ render_planning_item(item) }}
-        {%- endfor -%}
-      {%- endif -%}
     {%- endfor -%}
   {%- endif -%}
 {%- endfor -%}

--- a/server/templates/kuvalupaus_events_template.html
+++ b/server/templates/kuvalupaus_events_template.html
@@ -46,13 +46,25 @@
 {# One paragraph per agenda item; grouped by category if grouped_items present #}
 {%- for agenda in agendas or [] -%}
   {%- set grouped = agenda.get('grouped_items') -%}
+  {%- set has_multiple_dates = agenda.get('has_multiple_dates') -%}
   {%- if grouped and grouped.items() | count > 0 -%}
-    {%- for category, items in grouped.items() -%}
-      <h2>{{ category | upper }}</h2>
-      {%- set sorted_by_priority_items = items | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
-      {%- for item in sorted_by_priority_items -%}
-        {{ render_planning_item(item) }}
-      {%- endfor -%}
+    {%- for planning_date, categories in grouped.items() -%}
+      {%- if categories and categories.items() | count > 0 -%}
+        {%- if has_multiple_dates -%}
+          {%- if planning_date == 'Undated' -%}
+            <h2>{{ planning_date }}</h2>
+          {%- else -%}
+            <h2>{{ planning_date | fi_date(capitalized=True) }}</h2>
+          {%- endif -%}
+        {%- endif -%}
+        {%- for category, items in categories.items() if items -%}
+          <h2>{{ category | upper }}</h2>
+          {%- set sorted_by_priority_items = items | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+          {%- for item in sorted_by_priority_items -%}
+            {{ render_planning_item(item) }}
+          {%- endfor -%}
+        {%- endfor -%}
+      {%- endif -%}
     {%- endfor -%}
   {%- endif -%}
 {%- endfor -%}

--- a/server/templates/kuvalupaus_events_template.html
+++ b/server/templates/kuvalupaus_events_template.html
@@ -49,7 +49,8 @@
   {%- if grouped and grouped.items() | count > 0 -%}
     {%- for category, items in grouped.items() -%}
       <h2>{{ category | upper }}</h2>
-      {%- for item in items -%}
+      {%- set sorted_by_priority_items = items | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+      {%- for item in sorted_by_priority_items -%}
         {{ render_planning_item(item) }}
       {%- endfor -%}
     {%- endfor -%}

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -124,62 +124,73 @@
 {# ---------------------------------------- #}
 {# One paragraph per agenda item; grouped by category if grouped_items present #}
 {%- for agenda in agendas or [] -%}
-  {%- set main_topic_items = agenda.get('main_topic_items') -%}
-  {%- if main_topic_items and main_topic_items | count > 0 -%}
-    <h2>KÄRKIAIHEITAMME</h2>
-    {%- for item in main_topic_items -%}
-      {{ render_main_topic_item(item) }}
-    {%- endfor -%}
-  {%- endif -%}
   {%- set grouped = agenda.get('grouped_items') -%}
+  {%- set has_multiple_dates = agenda.get('has_multiple_dates') -%}
   {%- if grouped and grouped.items() | count > 0 -%}
-    {%- for category, items in grouped.items() -%}
-      <h2>{{ category | upper }}</h2>
-      {%- set coverage = namespace(intended=[], undecided=[], other=[], sent=[]) -%}
-      {%- for item in items -%}
-        {%- set status = item.news_coverage_status or {} -%}
-        {%- set status_name = (status.name or '') | lower -%}
-        {# If item has "latest_published_item", add it to coverage.sent and skip the coverage status_name checks #}
-        {%- if item.latest_published_item and item.latest_published_item._id -%}
-          {%- set _ = coverage.sent.append(item) -%}
-        {%- elif status_name == 'coverage intended' -%}
-          {%- set _ = coverage.intended.append(item) -%}
-        {%- elif status_name == 'coverage not decided yet' -%}
-          {%- set _ = coverage.undecided.append(item) -%}
-        {%- else -%}
-          {%- set _ = coverage.other.append(item) -%}
+    {%- for planning_date, categories in grouped.items() -%}
+      {%- if categories and categories.items() | count > 0 -%}
+        {%- if has_multiple_dates -%}
+          {%- if planning_date == 'Undated' -%}
+            <h2>{{ planning_date }}</h2>
+          {%- else -%}
+            <h2>{{ planning_date | fi_date(capitalized=True) }}</h2>
+          {%- endif -%}
         {%- endif -%}
-      {%- endfor -%}
+        {%- for category, items in categories.items() if items -%}
+          {%- if category == 'main_topic_items' -%}
+            <h2>KÄRKIAIHEITAMME</h2>
+            {%- for item in items -%}
+              {{ render_main_topic_item(item) }}
+            {%- endfor -%}
+          {%- else -%}
+            <h2>{{ category | upper }}</h2>
+            {%- set coverage = namespace(intended=[], undecided=[], other=[], sent=[]) -%}
+            {%- for item in items -%}
+              {%- set status = item.news_coverage_status or {} -%}
+              {%- set status_name = (status.name or '') | lower -%}
+              {# If item has "latest_published_item", add it to coverage.sent and skip the coverage status_name checks #}
+              {%- if item.latest_published_item and item.latest_published_item._id -%}
+                {%- set _ = coverage.sent.append(item) -%}
+              {%- elif status_name == 'coverage intended' -%}
+                {%- set _ = coverage.intended.append(item) -%}
+              {%- elif status_name == 'coverage not decided yet' -%}
+                {%- set _ = coverage.undecided.append(item) -%}
+              {%- else -%}
+                {%- set _ = coverage.other.append(item) -%}
+              {%- endif -%}
+            {%- endfor -%}
 
-      {%- set intended_items = coverage.intended | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
-      {%- for item in intended_items -%}
-        {{ render_planning_item(item) }}
-      {%- endfor -%}
+            {%- set intended_items = coverage.intended | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+            {%- for item in intended_items -%}
+              {{ render_planning_item(item) }}
+            {%- endfor -%}
 
-      {%- set sent_items = coverage.sent | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
-      {%- if sent_items -%}
-        <h3>LÄHETETYT</h3>
-        {%- for item in sent_items -%}
-          {{ render_planning_item(item) }}
+            {%- set sent_items = coverage.sent | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+            {%- if sent_items -%}
+              <h3>LÄHETETYT</h3>
+              {%- for item in sent_items -%}
+                {{ render_planning_item(item) }}
+              {%- endfor -%}
+            {%- endif -%}
+
+            {%- set undecided_items = coverage.undecided | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+            {%- if undecided_items -%}
+              <h2>JOS AIHETTA</h2>
+              {%- for item in undecided_items -%}
+                {{ render_planning_item(item) }}
+              {%- endfor -%}
+            {%- endif -%}
+
+            {%- set other_items = coverage.other | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+            {%- if other_items -%}
+              <h2>EI</h2>
+              {%- for item in other_items -%}
+                {{ render_planning_item(item) }}
+              {%- endfor -%}
+            {%- endif -%}
+          {%- endif -%}
         {%- endfor -%}
       {%- endif -%}
-
-      {%- set undecided_items = coverage.undecided | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
-      {%- if undecided_items -%}
-        <h2>JOS AIHETTA</h2>
-        {%- for item in undecided_items -%}
-          {{ render_planning_item(item) }}
-        {%- endfor -%}
-      {%- endif -%}
-
-      {%- set other_items = coverage.other | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
-      {%- if other_items -%}
-        <h2>EI</h2>
-        {%- for item in other_items -%}
-          {{ render_planning_item(item) }}
-        {%- endfor -%}
-      {%- endif -%}
-
     {%- endfor -%}
   {%- endif -%}
 {%- endfor -%}

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -151,27 +151,31 @@
         {%- endif -%}
       {%- endfor -%}
 
-      {%- for item in coverage.intended -%}
+      {%- set intended_items = coverage.intended | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+      {%- for item in intended_items -%}
         {{ render_planning_item(item) }}
       {%- endfor -%}
 
-      {%- if coverage.sent -%}
+      {%- set sent_items = coverage.sent | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+      {%- if sent_items -%}
         <h3>LÄHETETYT</h3>
-        {%- for item in coverage.sent -%}
+        {%- for item in sent_items -%}
           {{ render_planning_item(item) }}
         {%- endfor -%}
       {%- endif -%}
 
-      {%- if coverage.undecided -%}
+      {%- set undecided_items = coverage.undecided | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+      {%- if undecided_items -%}
         <h2>JOS AIHETTA</h2>
-        {%- for item in coverage.undecided -%}
+        {%- for item in undecided_items -%}
           {{ render_planning_item(item) }}
         {%- endfor -%}
       {%- endif -%}
 
-      {%- if coverage.other -%}
+      {%- set other_items = coverage.other | sort(attribute='stt_priority_numeric_sort', reverse=True) -%}
+      {%- if other_items -%}
         <h2>EI</h2>
-        {%- for item in coverage.other -%}
+        {%- for item in other_items -%}
           {{ render_planning_item(item) }}
         {%- endfor -%}
       {%- endif -%}

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -79,10 +79,16 @@
       {%- if cov_list | length > 0 -%}
         {%- set _ = third_parts.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
       {%- endif -%}
+      {%- if item.sttpicturewhatabouts -%}
+        {%- set whatabout_list = item.sttpicturewhatabouts if item.sttpicturewhatabouts is iterable else [item.sttpicturewhatabouts] -%}
+        {%- if whatabout_list | length > 0 -%}
+          {%- set _ = third_parts.append(whatabout_list | join(', ')) -%}
+        {%- endif -%}
+      {%- endif -%}
     {%- endif -%}
   {%- endif -%}
   {%- if first_parts %}
-    <p>- {{ first_parts | join(', ') }}{% if second_parts %} {{ second_parts | join(', ') }}.{% endif %}{% if third_parts %} {{ third_parts | join(', ') }}.{% endif %}</p>
+    <p>&ndash;&nbsp; {{ first_parts | join(', ') }}{% if second_parts %} {{ second_parts | join(', ') }}.{% endif %}{% if third_parts %} {{ third_parts | join(', ') }}.{% endif %}</p>
   {% endif -%}
 {%- endmacro %}
 
@@ -101,7 +107,7 @@
   {%- if category_str %}
     {% set _ = bits.append(category_str) %}
   {%- endif -%}
-  {%- if bits %}<p>- {{- bits | join(' ') -}}</p>{% endif -%}
+  {%- if bits %}<p>&ndash;&nbsp; {{- bits | join(' ') -}}</p>{% endif -%}
 {%- endmacro %}
 
 {# Actual rendering logic for the agenda items starts here #}

--- a/server/templates/merkkipaiva_template.html
+++ b/server/templates/merkkipaiva_template.html
@@ -19,7 +19,7 @@
     {% if item.planning_date %}
         {% set _ = parts.append("Juttu tulee " ~ (item.planning_date | fi_which_weekday)) %}
     {% endif %}
-    {%- if parts %}<p>- {{- parts | join(' ') -}}</p>{% endif -%}
+    {%- if parts %}<p>&ndash;&nbsp; {{- parts | join(' ') -}}</p>{% endif -%}
     <p></p>   {# blank line at the end #}
 {% endfor %}
 


### PR DESCRIPTION
feat: Improve Lupaus coverage metadata and rendering
    
    - collect sttpicturewhatabout fields from coverages, tighten status/image filters, and skip excluded priorities in _set_stt_fields
    - surface picturewhatabout values in Lupaus/Kuva templates and standardise bullet glyphs with en dash
    - align merkkipaiva template bullet styling with the new formatting

Add numeric priority sort field for Lupaus reports
    
    - derive stt_priority_numeric_sort during agenda enrichment and reuse it when selecting highest-priority items
    - order Kuvalupaus and Lupaus coverage buckets using the new field so higher priorities render first

Refactor Lupaus grouping and capitalize date headings
    
    - normalize planning_date handling and restructure grouping to date→category buckets in enrich_related.py, including per-date main-topic extraction and ordering
    - expose capitalized flag on fi_date filter for heading casing control
    - update Lupaus/Kuva templates to loop through the new grouped structure, render multi-date headings, and treat the main_topic_items bucket first
