### PR TITLE
update stt planning parser

### DIFF
--- a/server/features/ingest_planning.feature
+++ b/server/features/ingest_planning.feature
@@ -81,7 +81,8 @@ Feature: Ingest STT Planning items
                 },
                 "planning": {
                     "g2_content_type": "text",
-                    "slugline": "UKRAINA // Y\u00f6n seurantaa",
+                    "headline": "UKRAINA // Y\u00f6n seurantaa",
+                    "slugline": "Miten tilanne Ukrainan sodan ymp\u00e4rill\u00e4 ja Ukrainassa kehittyy?",
                     "scheduled": "2022-03-30T00:00:00+0000",
                     "genre": [{
                         "qcode": "sttgenre:1",
@@ -98,7 +99,7 @@ Feature: Ingest STT Planning items
                 },
                 "planning": {
                     "g2_content_type": "picture",
-                    "slugline": "Miten tilanne Ukrainan sodan ymp\u00e4rill\u00e4 ja Ukrainassa kehittyy?",
+                    "headline": "Miten tilanne Ukrainan sodan ymp\u00e4rill\u00e4 ja Ukrainassa kehittyy?",
                     "scheduled": "2022-03-30T00:00:00+0000",
                     "genre": [{
                         "qcode": "sttimage:27",

--- a/server/stt/stt_planning_ml.py
+++ b/server/stt/stt_planning_ml.py
@@ -558,6 +558,7 @@ class STTPlanningMLParser(STTParserMixin, PlanningMLParser):
                 "firstcreated": item.get("firstcreated"),
                 "planning": {
                     "slugline": item.get("slugline", ""),
+                    "headline": item.get("slugline", ""),
                     "g2_content_type": "text",
                     "scheduled": item.get("planning_date"),
                     "fields": [],

--- a/server/stt/stt_planning_ml.py
+++ b/server/stt/stt_planning_ml.py
@@ -145,6 +145,8 @@ class STTPlanningMLParser(STTParserMixin, PlanningMLParser):
         if coverage is not None:
             # Parse STT-specific fields for all coverages
             self.parse_stt_coverage_fields(news_coverage_elt, coverage)
+            if item.get("slugline"):
+                coverage["planning"]["slugline"] = item.get("slugline")
         return coverage
 
     def parse_stt_coverage_fields(
@@ -163,6 +165,10 @@ class STTPlanningMLParser(STTParserMixin, PlanningMLParser):
         # Parse all fields efficiently in single iterations
         self.parse_all_subject_fields(planning_elt, coverage)
         self.parse_non_subject_fields(planning_elt, coverage)
+
+        coverage["planning"]["multiple_content"] = (
+            coverage["planning"].get("g2_content_type") == "text"
+        )
 
     def parse_all_subject_fields(self, planning_elt: Element, coverage: Dict[str, Any]):
         """Parse all subject fields in a single iteration"""
@@ -551,11 +557,12 @@ class STTPlanningMLParser(STTParserMixin, PlanningMLParser):
                 "workflow_status": "draft",
                 "firstcreated": item.get("firstcreated"),
                 "planning": {
-                    "slugline": "",
+                    "slugline": item.get("slugline", ""),
                     "g2_content_type": "text",
                     "scheduled": item.get("planning_date"),
                     "fields": [],
                     "subject": [],
+                    "multiple_content": True,
                 },
                 "flags": {"placeholder": True},
             }

--- a/server/tests/stt_planning_ml_test.py
+++ b/server/tests/stt_planning_ml_test.py
@@ -32,6 +32,9 @@ class STTPlanningMLParserTest(TestCase):
         self.assertEqual(
             self.item["coverages"][0]["coverage_id"], "ID_WORKREQUEST_159799"
         )
+        for coverage in self.item["coverages"]:
+            if coverage["planning"]["g2_content_type"] == "text":
+                self.assertTrue(coverage["planning"]["multiple_content"])
 
     def test_department(self):
         category = self.item["anpa_category"][0]
@@ -91,13 +94,14 @@ class STTPlanningMLParserTest(TestCase):
         self.assertEqual(coverage["flags"], {"placeholder": True})
 
         planning = coverage["planning"]
-        self.assertEqual(planning["slugline"], "")
+        self.assertEqual(planning["slugline"], self.item["slugline"])
         self.assertEqual(planning["g2_content_type"], "text")
         self.assertEqual(
             planning["scheduled"], datetime(2023, 5, 29, 0, 0, tzinfo=tzutc())
         )
         self.assertEqual(planning["fields"], [])
         self.assertEqual(planning["subject"], [])
+        self.assertTrue(planning.get("multiple_content"))
 
         # Check news_coverage_status structure
         self.assertIn("news_coverage_status", coverage)
@@ -123,7 +127,8 @@ class STTPlanningMLParserTest(TestCase):
         )
 
         planning = coverage["planning"]
-        self.assertEqual(planning["slugline"], "Sudanissa taistelut jatkuvat")
+        self.assertEqual(planning["headline"], "Sudanissa taistelut jatkuvat")
+        self.assertEqual(planning["slugline"], self.item["slugline"])
         self.assertEqual(planning["g2_content_type"], "text")
         self.assertEqual(
             planning["scheduled"],

--- a/server/tests/stt_planning_ml_test.py
+++ b/server/tests/stt_planning_ml_test.py
@@ -95,13 +95,14 @@ class STTPlanningMLParserTest(TestCase):
 
         planning = coverage["planning"]
         self.assertEqual(planning["slugline"], self.item["slugline"])
+        self.assertEqual(planning["headline"], self.item["slugline"])
         self.assertEqual(planning["g2_content_type"], "text")
+        self.assertTrue(planning.get("multiple_content"))
         self.assertEqual(
             planning["scheduled"], datetime(2023, 5, 29, 0, 0, tzinfo=tzutc())
         )
         self.assertEqual(planning["fields"], [])
         self.assertEqual(planning["subject"], [])
-        self.assertTrue(planning.get("multiple_content"))
 
         # Check news_coverage_status structure
         self.assertIn("news_coverage_status", coverage)


### PR DESCRIPTION
- use planning headline as coverage slugline
- enable multiple content on text coverages

STT-1456