### PR TITLE
[STT-1469] Filter `sttsubj` from newsroom formatter

### DIFF
--- a/server/stt/stt_newsroom_ninjs_formatter.py
+++ b/server/stt/stt_newsroom_ninjs_formatter.py
@@ -14,6 +14,7 @@ FILTER_SUBJECT_SCHEMES = {
     "sttsource",
     "sttdepartment",
     "sttsubject",
+    "sttsubj",
     "sttdone1",
 }
 

--- a/server/tests/stt_newsroom_ninjs_formatter_test.py
+++ b/server/tests/stt_newsroom_ninjs_formatter_test.py
@@ -126,6 +126,7 @@ class STTNewsroomNinjsFormatterTest(TestCase):
                 {"name": "Source", "scheme": "sttsource"},
                 {"name": "Source", "scheme": "sttdepartment"},
                 {"name": "Source", "scheme": "sttsubject"},
+                {"name": "Koripallo", "scheme": "sttsubj"},
                 {"name": "Source", "scheme": "sttdone1"},
             ],
         }


### PR DESCRIPTION
### Purpose
Exclude subjects with scheme `sttsubj` as there were duplicates in the data.

Example:
```json
[
    {
        "qcode": "1",
        "name": "1 - yes",
        "scheme": "sttdone1"
    },
    {
        "qcode": "16",
        "name": "Urheilu",
        "scheme": "sttdepartment"
    },
    {
        "qcode": "15000000",
        "name": "Urheilu",
        "scheme": "sttsubj"
    },
    {
        "qcode": "15008000",
        "name": "Koripallo",
        "scheme": "sttsubj"
    },
    {
        "qcode": "15008001",
        "name": "NBA",
        "scheme": "sttsubj"
    },
    {
        "name": "STT",
        "qcode": "STT",
        "scheme": "sttsource"
    },
    {
        "qcode": "6",
        "scheme": "sttversion",
        "name": "Nettiuutiset"
    },
    {
        "name": "Urheilu",
        "qcode": "15000000",
        "parent": null,
        "iptc_subject": "15000000",
        "wikidata": "Q349",
        "translations": {
            "name": {
                "fi": "Urheilu",
                "en": "sport"
            }
        },
        "scheme": "topics"
    },
    {
        "name": "Koripallo",
        "qcode": "20000851",
        "parent": "15000000",
        "iptc_subject": "15008000",
        "wikidata": "Q5372",
        "translations": {
            "name": {
                "fi": "Koripallo",
                "en": "basketball"
            }
        },
        "scheme": "topics"
    }
]
```