### PR TITLE
[STT-1481] - STT NewsML parser ignores hyperlinks

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -196,7 +196,26 @@ AUDIT_EXPIRY_MINUTES = int(env("AUDIT_EXPIRY_MINUTES", 43200))
 #: The number records to be fetched for expiry.
 MAX_EXPIRY_QUERY_LIMIT = int(env("MAX_EXPIRY_QUERY_LIMIT", 1000))
 
-# HTML_TAGS_WHITELIST = ('h1', 'h2', 'h3', 'h4', 'h6', 'blockquote', 'figure', 'ul', 'ol', 'li', 'div', 'p', 'em', 'strong', 'i', 'b', 'a', 'pre')
+HTML_TAGS_WHITELIST = (
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h6",
+    "blockquote",
+    "figure",
+    "ul",
+    "ol",
+    "li",
+    "div",
+    "p",
+    "em",
+    "strong",
+    "i",
+    "b",
+    "a",
+    "pre",
+)
 
 # Disallowed characters for text fields (validation needs to be enabled in content profile)
 # DISALLOWED_CHARACTERS = ['!', '#', '$', '%', '&', '"', '(', ')', '*', '+', ',', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', ']', '\\', '^', '_', '`', '{', '|', '}', '~']

--- a/server/stt/parser.py
+++ b/server/stt/parser.py
@@ -59,6 +59,10 @@ class STTParser(STTParserMixin, STTNewsMLFeedParser):
         return content
 
     def _clean_body_html(self, body_elt):
+        """
+        This function retains the core’s cleaner behaviour while forcing <a> tags onto the allow-list
+        for html tags so ingesting doesn't ignore the hyperlinks
+        """
         if body_elt is None:
             return body_elt
 

--- a/server/stt/parser.py
+++ b/server/stt/parser.py
@@ -1,5 +1,4 @@
 from superdesk import etree as sd_etree
-from superdesk.core import get_app_config
 from superdesk.io.registry import register_feed_parser
 from superdesk.io.feed_parsers.stt_newsml import STTNewsMLFeedParser
 
@@ -30,7 +29,7 @@ class STTParser(STTParserMixin, STTNewsMLFeedParser):
     def parse_inline_content(self, tree, item):
         html_elt = tree.find(self.qname("html"))
         body_elt = html_elt.find(self.qname("body"))
-        body_elt = self._clean_body_html(body_elt)
+        body_elt = sd_etree.clean_html(body_elt)
         # replace <pre> with <p>
         for pre in body_elt.findall(".//pre"):
             pre.tag = "p"
@@ -57,32 +56,6 @@ class STTParser(STTParserMixin, STTNewsMLFeedParser):
             )
 
         return content
-
-    def _clean_body_html(self, body_elt):
-        """
-        This function retains the core’s cleaner behaviour while forcing <a> tags onto the allow-list
-        for html tags so ingesting doesn't ignore the hyperlinks
-        """
-        if body_elt is None:
-            return body_elt
-
-        allow_tags = list(get_app_config("HTML_TAGS_WHITELIST"))
-        if "a" not in allow_tags:
-            allow_tags.append("a")
-
-        if not isinstance(body_elt, sd_etree.html.HtmlElement):
-            body_elt = sd_etree.html.fromstring(
-                sd_etree.etree.tostring(body_elt, encoding="unicode")
-            )
-
-        safe_attrs = set(sd_etree.html.defs.safe_attrs)
-        if "class" in safe_attrs:
-            safe_attrs.remove("class")
-
-        cleaner = sd_etree.html.clean.Cleaner(
-            allow_tags=allow_tags, remove_unknown_tags=False, safe_attrs=safe_attrs
-        )
-        return cleaner.clean_html(body_elt)
 
     async def set_extra_fields(self, item, xml):
         """Adds extra fields"""

--- a/server/stt/parser.py
+++ b/server/stt/parser.py
@@ -1,4 +1,5 @@
 from superdesk import etree as sd_etree
+from superdesk.core import get_app_config
 from superdesk.io.registry import register_feed_parser
 from superdesk.io.feed_parsers.stt_newsml import STTNewsMLFeedParser
 
@@ -29,7 +30,7 @@ class STTParser(STTParserMixin, STTNewsMLFeedParser):
     def parse_inline_content(self, tree, item):
         html_elt = tree.find(self.qname("html"))
         body_elt = html_elt.find(self.qname("body"))
-        body_elt = sd_etree.clean_html(body_elt)
+        body_elt = self._clean_body_html(body_elt)
         # replace <pre> with <p>
         for pre in body_elt.findall(".//pre"):
             pre.tag = "p"
@@ -56,6 +57,28 @@ class STTParser(STTParserMixin, STTNewsMLFeedParser):
             )
 
         return content
+
+    def _clean_body_html(self, body_elt):
+        if body_elt is None:
+            return body_elt
+
+        allow_tags = list(get_app_config("HTML_TAGS_WHITELIST"))
+        if "a" not in allow_tags:
+            allow_tags.append("a")
+
+        if not isinstance(body_elt, sd_etree.html.HtmlElement):
+            body_elt = sd_etree.html.fromstring(
+                sd_etree.etree.tostring(body_elt, encoding="unicode")
+            )
+
+        safe_attrs = set(sd_etree.html.defs.safe_attrs)
+        if "class" in safe_attrs:
+            safe_attrs.remove("class")
+
+        cleaner = sd_etree.html.clean.Cleaner(
+            allow_tags=allow_tags, remove_unknown_tags=False, safe_attrs=safe_attrs
+        )
+        return cleaner.clean_html(body_elt)
 
     async def set_extra_fields(self, item, xml):
         """Adds extra fields"""

--- a/server/tests/fixtures/stt_newsml_hyperlink.xml
+++ b/server/tests/fixtures/stt_newsml_hyperlink.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<newsItem guid="urn:newsml:stt.fi::107319379" version="1" standardversion="2.12" conformance="power" xml:lang="fi-FI" xmlns:stt="http://www.stt-lehtikuva.fi/NewsML" standard="NewsML-G2" xsi:schemaLocation="http://iptc.org/std/nar/2006-10-01/ http://www.iptc.org/std/NewsML-G2/2.12/specification/NewsML-G2_2.12-spec-All-Power.xsd http://www.stt-lehtikuva.fi/NewsML http://www.stt-lehtikuva.fi/newsml/schema/STT-Lehtikuva_NewsML_G2.xsd" xmlns="http://iptc.org/std/nar/2006-10-01/" stt:formatversion="1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ><catalogRef href="http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_19.xml"/>
+<catalogRef href="http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_18.xml"/>
+<catalogRef href="http://www.stt-lehtikuva.fi/newsml/doc/stt-NewsCodesCatalog_1.xml"/>
+
+<itemMeta>
+
+<itemClass qcode="ninat:text"/>
+<provider literal="STT"/>
+<versionCreated>2025-11-21T08:20:16</versionCreated>
+<firstCreated>2025-11-21T08:20:11</firstCreated>
+<pubStatus qcode="stat:usable"/>
+<link rel="irel:seeAlso" href="https://www.hs.fi/politiikka/art-2000011637243.html"/>
+</itemMeta>
+<contentMeta>
+<urgency>3</urgency>
+<contentCreated>2025-11-21T08:20:11</contentCreated>
+<contentModified>2025-11-21T08:20:16</contentModified>
+<altId type="sttidtype:textid">122436579</altId>
+<located type="loctyp:City">
+<name>Helsinki</name>
+</located>
+<infoSource qcode="sttsource:1">
+<name>STT</name>
+</infoSource>
+<creator qcode="stteditorid:26945">
+<name>Lapintie Lassi</name>
+</creator>
+<altId type="sttidtype:runningnumber" environment="sttcounter:daily">stt 032</altId>
+<rating value="1" scalemin="1" scalemax="9" scaleunit="rscaleunit:number" ratingtype="sttrating:webprio"/>
+<subject type="cpnat:abstract" literal="Related topic id" qcode="stt-topics:693673"/>
+<subject type="cpnat:abstract" qcode="sttdone1:1"/>
+<subject type="cpnat:abstract" qcode="sttdepartment:3">
+<name>Kotimaa</name>
+</subject>
+<subject type="cpnat:abstract" qcode="sttsubj:10000000">
+<name>Vapaa-aika</name>
+</subject>
+<subject type="cpnat:abstract" qcode="sttsubj:10008000">
+<name>Yhdistystoiminta</name>
+</subject>
+<slugline/>
+<dateline>Helsinki</dateline>
+<by/>
+<description role="drol:summary"/>
+<headline>Helsingin Suomalaisen klubin puheenjohtajaksi valittiin konservatiivien tukema Olli Meretoja</headline><creditline>STT&#8211;</creditline>
+
+<genre qcode="sttgenre:1">
+<name>Pääjuttu</name>
+</genre>
+<genre qcode="sttversion:5">
+<name>Loppuversio</name>
+<related qcode="sttrel:actuallength" value="855"/>
+</genre>
+</contentMeta>
+<assert qcode="sttlocmeta:rich:16927">
+<name>Helsinki</name>
+<definition/>
+<geoAreaDetails/>
+<POIDetails>
+<address>
+<line> </line>
+<postalCode/>
+</address>
+</POIDetails>
+<broader type="cpnat:geoArea" qcode="sttcity:35">
+<name>Helsinki</name>
+</broader>
+<broader type="cpnat:geoArea" qcode="sttstate:31">
+<name>Uusimaa</name>
+</broader>
+<broader type="cpnat:geoArea" qcode="sttcountry:1">
+<name>Suomi</name>
+</broader>
+<broader type="cpnat:geoArea" qcode="wldreg:150">
+<name>Eurooppa</name>
+</broader>
+</assert>
+<contentSet>
+<inlineXML contenttype="xhtml/xml">
+<html>
+<body>
+<p>Naisjäsenyyskysymyksen repimä Helsingin Suomalainen Klubi valitsi torstaisessa syyskokouksessaan jälkeen uudeksi puheenjohtajakseen professori Olli Meretojan, 78.</p>
+<p>Meretoja on lääketieteen ja kirurgian tohtori, joka on toiminut aiemmin klubin johtokunnan jäsenenä, viestintätoimikunnan puheenjohtajana ja jäsenlehden päätoimittajana.</p>
+<p>Nimitystoimikunta oli ehdottanut johtokunnan uudeksi puheenjohtajaksi professori Erkki Leppävuorta, uutisoi <a href="https://www.hs.fi/politiikka/art-2000011637243.html">Helsingin Sanomat</a> keskiviikkona. Meretojan valintaa puheenjohtajaksi Leppävuoren ohi oli tukenut erillinen konservatiivinen taustaryhmä.</p>
+<p>Lokakuussa jäsenistön vähemmistö torjui naisten oikeuden liittyä klubin jäseniksi. Naisjäsenyyttä kannatti 66,5 prosenttia, mutta muutos olisi edellyttänyt kolmen neljäsosan kannatusta.</p></body>
+</html>
+</inlineXML>
+</contentSet></newsItem>

--- a/server/tests/parser_test.py
+++ b/server/tests/parser_test.py
@@ -1,3 +1,4 @@
+from typing import Tuple, cast, Any
 from tests import TestCase
 
 
@@ -67,10 +68,13 @@ class STTParserTestCase(TestCase):
 
 class STTParserHyperlinkTestCase(TestCase):
     fixture = "stt_newsml_hyperlink.xml"
-    app_config = {
+    app_config: dict[str, Any] = {
         **TestCase.app_config,
-        "HTML_TAGS_WHITELIST": tuple(
-            tag for tag in TestCase.app_config["HTML_TAGS_WHITELIST"] if tag != "a"
+        "HTML_TAGS_WHITELIST": cast(
+            Tuple[str, ...],
+            tuple(
+                tag for tag in TestCase.app_config["HTML_TAGS_WHITELIST"] if tag != "a"
+            ),
         ),
     }
 

--- a/server/tests/parser_test.py
+++ b/server/tests/parser_test.py
@@ -1,4 +1,3 @@
-from typing import Tuple, cast, Any
 from tests import TestCase
 
 
@@ -68,15 +67,6 @@ class STTParserTestCase(TestCase):
 
 class STTParserHyperlinkTestCase(TestCase):
     fixture = "stt_newsml_hyperlink.xml"
-    app_config: dict[str, Any] = {
-        **TestCase.app_config,
-        "HTML_TAGS_WHITELIST": cast(
-            Tuple[str, ...],
-            tuple(
-                tag for tag in TestCase.app_config["HTML_TAGS_WHITELIST"] if tag != "a"
-            ),
-        ),
-    }
 
     def test_preserve_anchor_href(self):
         body_html = self.item["body_html"]

--- a/server/tests/parser_test.py
+++ b/server/tests/parser_test.py
@@ -65,6 +65,24 @@ class STTParserTestCase(TestCase):
         assert genres[0]["qcode"] == "sttgenre:1"
 
 
+class STTParserHyperlinkTestCase(TestCase):
+    fixture = "stt_newsml_hyperlink.xml"
+    app_config = {
+        **TestCase.app_config,
+        "HTML_TAGS_WHITELIST": tuple(
+            tag for tag in TestCase.app_config["HTML_TAGS_WHITELIST"] if tag != "a"
+        ),
+    }
+
+    def test_preserve_anchor_href(self):
+        body_html = self.item["body_html"]
+        expected_link = (
+            '<a href="https://www.hs.fi/politiikka/art-2000011637243.html" '
+            'target="_blank">Helsingin Sanomat</a>'
+        )
+        self.assertIn(expected_link, body_html)
+
+
 class STTParserPRETestCase(TestCase):
     fixture = "stt_newsml_pre_test.xml"
 


### PR DESCRIPTION
### Purpose
- This PR ensures STT NewsML ingest preserves the hyperlinks using the core html cleaner function but with an updated config to include <a> tag

### What Has Changed
- `HTML_TAGS_WHITELIST` in the settings.py now includes the <a> tag
- Added tests