### PR TITLE
fix stt newsml formatter errors from sentry

### DIFF
--- a/server/stt/publish/stt_newsml_g2.py
+++ b/server/stt/publish/stt_newsml_g2.py
@@ -426,12 +426,12 @@ class STTNewsmLG2Formatter(NewsMLG2Formatter):
 
             edNoteStr = newsroomnoteStr + (article.get("ednote") or "")
             SubElement(itemMeta, "edNote", attrib={"role": "sttnote:private"}).text = (
-                edNoteStr
+                edNoteStr.strip()
             )
         else:
             edNoteStr = article.get("ednote", "")
             SubElement(itemMeta, "edNote", attrib={"role": "sttnote:private"}).text = (
-                edNoteStr
+                edNoteStr.strip()
             )
 
         # Public edNote - to all other profiles but 'nettiuutinen'

--- a/server/stt/publish/stt_newsml_g2.py
+++ b/server/stt/publish/stt_newsml_g2.py
@@ -424,7 +424,7 @@ class STTNewsmLG2Formatter(NewsMLG2Formatter):
             else:
                 newsroomnoteStr = newsroomnoteStr + ". "
 
-            edNoteStr = newsroomnoteStr + article.get("ednote", "")
+            edNoteStr = newsroomnoteStr + (article.get("ednote") or "")
             SubElement(itemMeta, "edNote", attrib={"role": "sttnote:private"}).text = (
                 edNoteStr
             )
@@ -623,8 +623,13 @@ class STTNewsmLG2Formatter(NewsMLG2Formatter):
                 subheadline = etree.Element("h2")
 
                 # Find the paragraph and get the content to H2
-                subheadline.text = htmltree.xpath("//p/text()")[0]
-                body.append(subheadline)
+                try:
+                    subheadline_p = htmltree.xpath("//p")[0]
+                except IndexError:
+                    subheadline_p = None
+                if subheadline_p is not None and subheadline_p.text_content():
+                    subheadline.text = subheadline_p.text_content()
+                    body.append(subheadline)
 
         # Format body content (can be overridden in subclasses)
         self.format_contentSet_body(article, body)

--- a/server/tests/__init__.py
+++ b/server/tests/__init__.py
@@ -7,6 +7,11 @@ from apps.prepopulate.app_populate import AppPopulateCommand
 from stt.parser import STTParser
 
 
+def fixture(filename):
+    dirname = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(dirname, "fixtures", filename)
+
+
 class TestCase(CoreTestCase):
     fixture = None
     parser_class = STTParser

--- a/server/tests/stt_newsml_g2_test.py
+++ b/server/tests/stt_newsml_g2_test.py
@@ -114,6 +114,11 @@ class TestSTTNewsmLG2Formatter(TestCase):
         }
         newsml = await self.format_and_parse(article)
         assert newsml is not None
+        item_meta = newsml.find("itemMeta", namespaces=newsml.nsmap)
+        ednotes = item_meta.findall("edNote", namespaces=newsml.nsmap)
+        assert 2 == len(ednotes)
+        assert ednotes[1].text == "Mittaversio (printtiin)."
+        assert ednotes[1].get("role") == "sttnote:private"
 
     async def test_subheadline_error(self):
         article = {

--- a/server/tests/stt_newsml_g2_test.py
+++ b/server/tests/stt_newsml_g2_test.py
@@ -1,5 +1,6 @@
-from tests import TestCase
 import lxml.etree as etree
+
+from tests import TestCase
 
 from stt.publish.stt_newsml_g2 import format_filename, STTNewsmLG2Formatter
 
@@ -97,3 +98,33 @@ class TestSTTNewsmLG2Formatter(TestCase):
         link = signal.find("link", namespaces=newsml.nsmap)
         assert link is not None
         assert link.get("guidref") == "urn:newsml:stt:fi::original"
+
+    async def test_ednote_error(self):
+        article = {
+            "type": "text",
+            "guid": "ednote-test",
+            "ednote": None,
+            "subject": [
+                {
+                    "name": "Mittaversio (printtiin)",
+                    "qcode": "printformat",
+                    "scheme": "sttnewsroomnote",
+                },
+            ],
+        }
+        newsml = await self.format_and_parse(article)
+        assert newsml is not None
+
+    async def test_subheadline_error(self):
+        article = {
+            "type": "text",
+            "guid": "subheadline-test",
+            "extra": {"sttsubheadline": "<p><b>Subheadline.</b></p>"},
+            "body_html": "<p>Body</p>",
+        }
+        newsml = await self.format_and_parse(article)
+        assert newsml is not None
+        contentSet = etree.tostring(
+            newsml.find("contentSet", namespaces=newsml.nsmap), encoding="unicode"
+        )
+        assert "<h2>Subheadline.</h2>" in contentSet


### PR DESCRIPTION
- fix error when ednote is None
- fix error when subheadline has additional markup

STT-1497