### PR TITLE
Fix/lupaus published items image type

### DIFF
--- a/server/stt/helpers/mongo_helpers.py
+++ b/server/stt/helpers/mongo_helpers.py
@@ -83,7 +83,8 @@ def get_published_items_with_sttnewsroomnote_by_planning_id(
 
     Executes the aggregation pipeline:
 
-        match planning -> compute sttimagetype from graphic coverage -> unwind coverages ->
+        match planning -> collect all sttimagetype names from picture/graphic coverages ->
+        combine them into a comma-separated sttimagetype string -> unwind coverages ->
         convert assignment_id to ObjectId -> filter null assignments -> lookup published ->
         unwind -> merge sttimagetype into the published document.
 
@@ -104,73 +105,69 @@ def get_published_items_with_sttnewsroomnote_by_planning_id(
     pipeline = [
         {"$match": {"_id": planning_id}},
         {
-            # 1) Compute sttimagetype from the *graphic* coverage (once per planning doc)
-            "$set": {
-                "sttimagetype": {
-                    "$let": {
-                        "vars": {
-                            # first coverage where planning.g2_content_type == "graphic"
-                            "graphicCoverage": {
-                                "$first": {
-                                    "$filter": {
-                                        "input": "$coverages",
-                                        "as": "c",
-                                        "cond": {
-                                            "$eq": [
-                                                "$$c.planning.g2_content_type",
-                                                "graphic",
-                                            ]
-                                        },
-                                    }
-                                }
-                            },
-                            "subjects": {
-                                "$let": {
-                                    "vars": {
-                                        "gc": {
-                                            "$first": {
-                                                "$filter": {
-                                                    "input": "$coverages",
-                                                    "as": "c",
-                                                    "cond": {
-                                                        "$eq": [
-                                                            "$$c.planning.g2_content_type",
-                                                            "graphic",
-                                                        ]
-                                                    },
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "in": {"$ifNull": ["$$gc.planning.subject", []]},
-                                }
-                            },
-                        },
-                        "in": {
-                            "$let": {
-                                "vars": {
-                                    "match": {
-                                        "$first": {
-                                            "$filter": {
-                                                "input": "$$subjects",
-                                                "as": "s",
-                                                "cond": {
-                                                    "$eq": [
-                                                        "$$s.scheme",
-                                                        "sttimagetype",
-                                                    ]
-                                                },
-                                            }
-                                        }
-                                    }
-                                },
-                                "in": {
-                                    "$ifNull": [
-                                        "$$match.qcode",
-                                        {"$ifNull": ["$$match.name", ""]},
-                                    ]
+            # 1) Collect all sttimagetype subject names from graphic coverages
+            "$addFields": {
+                "sttimagetypes": {
+                    "$map": {
+                        "input": {
+                            "$filter": {
+                                "input": "$coverages",
+                                "as": "c",
+                                "cond": {
+                                    "$in": [
+                                        "$$c.planning.g2_content_type",
+                                        ["graphic", "picture"],
+                                    ],
                                 },
                             }
+                        },
+                        "as": "graphic",
+                        "in": {
+                            "$map": {
+                                "input": {
+                                    "$filter": {
+                                        "input": {
+                                            "$ifNull": [
+                                                "$$graphic.planning.subject",
+                                                [],
+                                            ]
+                                        },
+                                        "as": "s",
+                                        "cond": {"$eq": ["$$s.scheme", "sttimagetype"]},
+                                    }
+                                },
+                                "as": "subject",
+                                "in": "$$subject.name",
+                            }
+                        },
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "sttimagetype": {
+                    "$reduce": {
+                        "input": {
+                            "$reduce": {
+                                "input": "$sttimagetypes",
+                                "initialValue": [],
+                                "in": {"$concatArrays": ["$$value", "$$this"]},
+                            }
+                        },
+                        "initialValue": "",
+                        "in": {
+                            "$cond": [
+                                {"$eq": ["$$value", ""]},
+                                {"$ifNull": ["$$this", ""]},
+                                {
+                                    "$cond": [
+                                        {"$eq": ["$$this", ""]},
+                                        "$$value",
+                                        {"$concat": ["$$value", ", ", "$$this"]},
+                                    ]
+                                },
+                            ]
                         },
                     }
                 }

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -315,7 +315,7 @@ def get_numeric_value_from_priority(priority: str) -> str:
     can be converted to an integer, it is returned (as a string). If not, or if the
     expected format is not found, the function returns an empty string.
 
-    There's one exception: "Vain tulokset" and in that case we return "Vain tulokset"
+    There's two exceptions: "Vain tulokset" / "Vain tsekkaus" and in that case we return the priority string as is.
 
     Args:
         priority: A string representing the priority.
@@ -325,7 +325,7 @@ def get_numeric_value_from_priority(priority: str) -> str:
 
     if not priority:
         return ""
-    if priority == "Vain tulokset":
+    if priority == "Vain tulokset" or priority == "Vain tsekkaus":
         return priority
     try:
         # Find the last '(' and ')' and extract the content between them


### PR DESCRIPTION
fix: include all picture/graphic sttimagetypes in Lupaus lookup
    
    - collect every sttimagetype subject from coverages with g2_content_type graphic or picture
    - flatten the names into a comma-separated sttimagetype string via aggregation

fix: get_numeric_value_from_priority
    
    - Skip numeric parsing if priority is "Vain tsekkaus"