### PR TITLE
Feat/ignore corrected if oikaisu exist

### DIFF
--- a/server/stt/oikaisut_korjaukset_export/enrich_items.py
+++ b/server/stt/oikaisut_korjaukset_export/enrich_items.py
@@ -7,6 +7,30 @@ from stt.helpers.template_helpers import exclude_drafts
 logger = logging.getLogger(__name__)
 
 
+def _is_oikaisu(item: Dict[str, Any]) -> bool:
+    """
+    Determine whether the provided item represents an "oikaisu" correction.
+
+    An item is considered an oikaisu if its "genre" field (which may be a dict
+    or a list of dicts) contains an entry with the qcode "sttgenre:11".
+
+    Args:
+        item: A dictionary representing the item metadata.
+
+    Returns:
+        True if the item is classified as an oikaisu; otherwise, False.
+    """
+    genre = item.get("genre")
+    if isinstance(genre, dict):
+        return genre.get("qcode") == "sttgenre:11"
+    if isinstance(genre, list):
+        return any(
+            isinstance(entry, dict) and entry.get("qcode") == "sttgenre:11"
+            for entry in genre
+        )
+    return False
+
+
 def _get_related_corrected_published_items(planning_id: str) -> List[Dict[str, Any]]:
     # first search from "delivery" collection by planning_id
     deliveries = find_many(
@@ -52,6 +76,13 @@ def _get_related_corrected_published_items(planning_id: str) -> List[Dict[str, A
             if items:
                 # add all found items to published_items
                 published_items.extend(items)
+
+    # If there is at least one oikaisu for this planning_id, ignore korjaus items.
+    if any(_is_oikaisu(item) for item in published_items):
+        published_items = [
+            item for item in published_items if item.get("state") != "corrected"
+        ]
+
     return published_items
 
 

--- a/server/templates/oikaisut_korjaukset_template.html
+++ b/server/templates/oikaisut_korjaukset_template.html
@@ -41,16 +41,7 @@
     {%- if genre_name %}{% set _ = second_parts.append(genre_name) %}{% endif -%}
     {%- if item.corrected_published_item.profile %}{% set _ = second_parts.append(item.corrected_published_item.profile) %}{% endif -%}
     {%- if item.corrected_published_item.headline %}{% set _ = second_parts.append('"' ~ item.corrected_published_item.headline ~ '"') %}{% endif -%}
-    <p>– {{ second_parts | join(', ') }}.
-    {%- set ednote = item.corrected_published_item.ednote | trim if item.corrected_published_item.ednote else '' -%}
-    {%- if ednote %} {{ ednote if ednote.endswith('.') else ednote ~ '.' }}{% endif -%}
-        {% if item.corrected_published_item.firstpublished %}
-            Lähetetty klo {{ item.corrected_published_item.firstpublished | fi_time }}
-        {% endif %}
-        {% if item.corrected_published_item.body_html %}
-            , {{ item.corrected_published_item.body_html | count_body_html_characters }} merkkiä.
-        {% endif %}
-    </p>
+    <p>– {{ second_parts | join(', ') }}. {%- set ednote = item.corrected_published_item.ednote | trim if item.corrected_published_item.ednote else '' -%}{%- if ednote %} {{ ednote if ednote.endswith('.') else ednote ~ '.' }}{% endif -%}{% if item.corrected_published_item.firstpublished %} Lähetetty klo {{ item.corrected_published_item.firstpublished | fi_time }}{% endif %}{% if item.corrected_published_item.body_html %}, {{ item.corrected_published_item.body_html | count_body_html_characters }} merkkiä.{% endif %}</p>
     <br />
 
 {% endfor %}


### PR DESCRIPTION
 feat: filter corrected items out if "oikaisu" exists
    
    - Added helper _is_oikaisu() to detect genre.qcode == "sttgenre:11" (handles genre as dict or list).
    - After collecting related published items for a planning_id, if any oikaisu exists, the function filters out all items where state == "corrected".

refactor: small tweak to oikaisut_korjaukset_template formatting