### PR TITLE
feat: include "kainalo" and "faktalaatikko" to lupaus report

### DIFF
--- a/server/stt/helpers/mongo_helpers.py
+++ b/server/stt/helpers/mongo_helpers.py
@@ -278,6 +278,7 @@ def get_published_items_by_planning_id_and_genre_qcodes(
             "operation": 1,
             "profile": 1,
             "state": 1,
+            "versioncreated": 1,
         }
 
     items = find_many(

--- a/server/stt/helpers/mongo_helpers.py
+++ b/server/stt/helpers/mongo_helpers.py
@@ -228,3 +228,68 @@ def get_published_items_with_sttnewsroomnote_by_planning_id(
             exc,
         )
         return []
+
+
+def get_published_items_by_planning_id_and_genre_qcodes(
+    planning_id: str,
+    genre_qcodes: List[str],
+    projection: Optional[Dict[str, int]] = None,
+) -> List[Dict[str, Any]]:
+    """Return published items linked to *planning_id* filtered by genre qcodes.
+
+    This follows the relation:
+
+        planning._id -> delivery.planning_id -> published.item_id (via delivery.item_id)
+
+    Only delivery rows with ``item_state == 'published'`` are considered.
+    The published query matches any item whose ``genre.qcode`` is one of
+    ``genre_qcodes``.
+    """
+
+    if not planning_id or not genre_qcodes:
+        return []
+
+    deliveries = find_many(
+        "delivery",
+        {"planning_id": planning_id, "item_state": "published"},
+        projection={"item_id": 1, "_id": 0},
+    )
+
+    item_ids_set = set()
+    for delivery in deliveries:
+        if not isinstance(delivery, dict):
+            continue
+        item_id = delivery.get("item_id")
+        if not item_id:
+            continue
+        item_ids_set.add(str(item_id))
+
+    item_ids = sorted(item_ids_set)
+    if not item_ids:
+        return []
+
+    if projection is None:
+        projection = {
+            "assignment_id": 1,
+            "firstpublished": 1,
+            "genre": 1,
+            "body_html": 1,
+            "item_id": 1,
+            "operation": 1,
+            "profile": 1,
+            "state": 1,
+        }
+
+    items = find_many(
+        "published",
+        {
+            "item_id": {"$in": item_ids},
+            "genre.qcode": {"$in": genre_qcodes},
+            "state": {"$in": ["published"]},
+        },
+        projection=projection,
+    )
+
+    # Stable ordering for exports/UI usage: newest first when the field exists.
+    items.sort(key=lambda item: (item or {}).get("versioncreated") or "", reverse=True)
+    return items

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -4,11 +4,28 @@ import logging
 
 from stt.helpers.mongo_helpers import (
     find_many,
+    get_published_items_by_planning_id_and_genre_qcodes,
     get_published_items_with_sttnewsroomnote_by_planning_id,
 )
 from stt.helpers.template_helpers import exclude_drafts
 
 logger = logging.getLogger(__name__)
+
+
+def _item_has_genre_qcode(item: Dict[str, Any], qcode: str) -> bool:
+    """Return True when item.genre contains a matching qcode.
+
+    Tolerates ``genre`` being either a dict or a list of dicts.
+    """
+
+    if not item or not qcode:
+        return False
+    genre = item.get("genre")
+    if isinstance(genre, dict):
+        return genre.get("qcode") == qcode
+    if isinstance(genre, list):
+        return any(isinstance(g, dict) and g.get("qcode") == qcode for g in genre)
+    return False
 
 
 def _collect_event_ids(agendas: List[Dict[str, Any]]) -> List[str]:
@@ -401,7 +418,7 @@ def _set_stt_fields(
     item_type: str,
 ) -> List[Dict[str, Any]]:
     """
-    Enrich agendas with the metadata required by the Lupaus/Kuva exports.
+    Enrich agendas with the metadata required by the Lupaus/Kuvalupaus exports.
 
     For each planning item the function:
     - attaches coverage metadata (``news_coverage_status``, ``sttimagetypes``,
@@ -421,6 +438,8 @@ def _set_stt_fields(
 
     Returns the filtered/enriched agendas list.
     """
+
+    genre_cache: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
 
     for ag in agendas or []:
         new_items: List[Dict[str, Any]] = []
@@ -453,6 +472,34 @@ def _set_stt_fields(
             latest_published_item = _get_latest_published_item(published_related_items)
             # attach latest published item to planning item
             pl["latest_published_item"] = latest_published_item
+
+            planning_id = pl.get("_id")
+            planning_id_str = str(planning_id) if planning_id else ""
+            cached = genre_cache.get(planning_id_str) if planning_id_str else None
+            if cached is None and planning_id_str:
+                genre_items = get_published_items_by_planning_id_and_genre_qcodes(
+                    planning_id_str, ["sttgenre:23", "sttgenre:2"]
+                )
+                cached = {
+                    "fact_box_items": [
+                        item
+                        for item in genre_items
+                        if _item_has_genre_qcode(item, "sttgenre:23")
+                    ],
+                    "armpit_items": [
+                        item
+                        for item in genre_items
+                        if _item_has_genre_qcode(item, "sttgenre:2")
+                    ],
+                }
+                genre_cache[planning_id_str] = cached
+
+            pl["fact_box_items"] = (
+                cached.get("fact_box_items", []) if cached is not None else []
+            )
+            pl["armpit_items"] = (
+                cached.get("armpit_items", []) if cached is not None else []
+            )
             _set_priority_fields(pl, item_type)
             if "stt_priority" not in pl:
                 continue  # exclude items without "stt_priority" key set (eg. "Vain tsekkaus" items)
@@ -638,7 +685,7 @@ def enrich_planning_agendas(
     agendas: List[Dict[str, Any]], item_type: str
 ) -> List[Dict[str, Any]]:
     """
-    Enrich every planning agenda with the data required by the Lupaus exports.
+    Enrich every planning agenda with the data required by the Lupaus / Kuvalupaus exports.
 
     The function:
     - drops draft agenda items

--- a/server/templates/lupaus_events_template.html
+++ b/server/templates/lupaus_events_template.html
@@ -5,6 +5,16 @@
 {# Enrich agendas with related events (adds item.related_events_expanded) #}
 {% set agendas = enrich_planning_agendas(agendas, 'teksti') %}
 
+{# Macro to render fact_box_items "Faktalaatikko" / armpit_items "Kainalo" #}
+
+{% macro render_fact_box_armpit_items(items, type) -%}
+  {%- set parts = [] -%}
+  {%- for item in items -%}
+    {% set _ = parts.append(type ~ ", lähetetty klo " ~ (item.firstpublished | fi_time) ~ ", " ~ (item.body_html | count_body_html_characters) ~ " merkkiä") %}
+  {%- endfor -%}
+  {%- if parts %}{{ parts | join(' ') }}{% endif -%}
+{%- endmacro %}
+
 {% macro lupaus_location(location) -%}
     {%- set loc = location[0] if location and location[0] and location[0].address else None -%}
     {%- if loc -%}
@@ -37,6 +47,8 @@
   {%- set first_parts = [] -%}
   {%- set second_parts = [] -%}
   {%- set third_parts = [] -%}
+  {%- set fourth_parts = [] -%}
+  {%- set fifth_parts = [] -%}
   {%- set latest_published_item_description = "" -%}
   {%- if item.slugline -%}
     {%- set slug = item.slugline | trim -%}
@@ -82,22 +94,35 @@
     {# Call the priority macro #}
     {%- set urg = stt_priority_text(item) -%}
     {%- if urg %}{% set _ = third_parts.append(urg) %}{% endif -%}
+    {# Add fact_box / armpit if available #}
+    {%- if item.fact_box_items and item.fact_box_items | length > 0 -%}
+      {%- set fact_box_text = render_fact_box_armpit_items(item.fact_box_items, 'Faktalaatikko') -%}
+      {%- if fact_box_text %}{% set _ = fourth_parts.append(fact_box_text) %}{% endif -%}
+    {%- endif -%}
+    {%- if item.armpit_items and item.armpit_items | length > 0 -%}
+      {%- set armpit_text = render_fact_box_armpit_items(item.armpit_items, 'Kainalo') -%}
+      {%- if armpit_text %}{% set _ = fourth_parts.append(armpit_text) %}{% endif -%}
+    {%- endif -%}
     {# Add coverages if available #}
     {%- if item.sttimagetypes -%}
       {%- set cov_list = item.sttimagetypes if item.sttimagetypes is iterable else [item.sttimagetypes] -%}
       {%- if cov_list | length > 0 -%}
-        {%- set _ = third_parts.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
+        {%- set _ = fifth_parts.append('Kuvitus: ' ~ (cov_list | join(', '))) -%}
       {%- endif -%}
       {%- if item.sttpicturewhatabouts -%}
         {%- set whatabout_list = item.sttpicturewhatabouts if item.sttpicturewhatabouts is iterable else [item.sttpicturewhatabouts] -%}
         {%- if whatabout_list | length > 0 -%}
-          {%- set _ = third_parts.append(whatabout_list | join(', ')) -%}
+          {%- set _ = fifth_parts.append(whatabout_list | join(', ')) -%}
         {%- endif -%}
       {%- endif -%}
     {%- endif -%}
   {%- endif -%}
+  {%- set second_text = (second_parts | join(', ')) | trim -%}
+  {%- set third_text = (third_parts | join(', ')) | trim -%}
+  {%- set fourth_text = (fourth_parts | join('. ')) | trim -%}
+  {%- set fifth_text = (fifth_parts | join(', ')) | trim -%}
   {%- if first_parts %}
-    <p>&ndash;&nbsp; {{ first_parts | join(', ') }}{% if latest_published_item_description %} {{ latest_published_item_description }}{% endif %}{% if second_parts %} {{ second_parts | join(', ') }}.{% endif %}{% if third_parts %} {{ third_parts | join(', ') }}.{% endif %}</p>
+    <p>&ndash;&nbsp; {{ first_parts | join(', ') }}{% if latest_published_item_description %} {{ latest_published_item_description }}{% endif %}{% if second_text %} {{ second_text }}.{% endif %}{% if third_text %} {{ third_text }}.{% endif %}{% if fourth_text %} {{ fourth_text }}.{% endif %}{% if fifth_text %} {{ fifth_text }}.{% endif %}</p>
   {% endif -%}
 {%- endmacro %}
 


### PR DESCRIPTION
- Added a new Mongo helper mongo_helpers.py get_published_items_by_planning_id_and_genre_qcodes(planning_id, genre_qcodes, projection=None) that follows planning_id -> delivery(planning_id,item_state=published) -> published(item_id) and filters by genre.qcode.
- Wired it into enrich_related.py _set_stt_fields to populate:
  - pl["fact_box_items"] for sttgenre:23
  - pl["armpit_items"] for sttgenre:2
  - Includes a small per-planning-id cache to avoid repeated DB lookups within one run.
- Edited lupaus_events_template.html to include "kainalo" / "faktalaatikko" if data exists

https://trello.com/c/3qoQGs1r