### PR TITLE
[STT-1537] - Monday as the starting day in config

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -52,6 +52,8 @@ module.exports = function (grunt) {
       dateformat: "DD.MM.YYYY",
     },
 
+    startingDay: 1, // Monday
+
     features: {
       swimlane: {defaultNumberOfColumns: 4},
       noTakes: true /* hide takes */,
@@ -155,8 +157,6 @@ module.exports = function (grunt) {
         },
       },
     },
-
-    startingDay: 1, // Monday
 
     /* display alternative labels for some stings */
     langOverride: {

--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -156,6 +156,8 @@ module.exports = function (grunt) {
       },
     },
 
+    startingDay: 1, // Monday
+
     /* display alternative labels for some stings */
     langOverride: {
       en: {


### PR DESCRIPTION
### Purpose
This pull request introduces a configuration change to set Monday as the starting day of the week.

#### Configuration update:
  * Set `startingDay` to `1` (Monday) in `client/superdesk.config.js` to change the default start of the week.
  
<img width="852" alt="calendar start day" src="https://github.com/user-attachments/assets/937e1430-0764-4b38-b7f0-7a4c2ff379a1" />

[STT-1537]

[STT-1537]: https://sofab.atlassian.net/browse/STT-1537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ