### PR TITLE
feat: Added exclude_merkkipaivapalvelu_items helper

### DIFF
--- a/server/stt/helpers/template_helpers.py
+++ b/server/stt/helpers/template_helpers.py
@@ -14,3 +14,30 @@ def exclude_drafts(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     filtered_items = [item for item in items if item.get("state") != "draft"]
     return filtered_items
+
+
+def exclude_merkkipaivapalvelu_items(
+    items: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Exclude items belonging to category qcode "5" (Merkkipäiväpalvelu).
+
+    The function inspects the ``anpa_category`` field which is expected to be a list
+    of dicts like ``{"qcode": "5", "name": "Merkkipäiväpalvelu"}``.
+
+    Args:
+        items: A list of item dictionaries.
+
+    Returns:
+        A new list excluding items where any ``anpa_category`` entry has
+        ``qcode == "5"``.
+    """
+
+    filtered_items: List[Dict[str, Any]] = []
+    for item in items:
+        categories = item.get("anpa_category")
+        if isinstance(categories, list) and any(
+            isinstance(cat, dict) and cat.get("qcode") == "5" for cat in categories
+        ):
+            continue
+        filtered_items.append(item)
+    return filtered_items

--- a/server/stt/lupaus_export/enrich_related.py
+++ b/server/stt/lupaus_export/enrich_related.py
@@ -7,7 +7,10 @@ from stt.helpers.mongo_helpers import (
     get_published_items_by_planning_id_and_genre_qcodes,
     get_published_items_with_sttnewsroomnote_by_planning_id,
 )
-from stt.helpers.template_helpers import exclude_drafts
+from stt.helpers.template_helpers import (
+    exclude_drafts,
+    exclude_merkkipaivapalvelu_items,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -707,6 +710,8 @@ def enrich_planning_agendas(
     for ag in agendas:
         # Exclude draft items
         items = exclude_drafts(ag.get("items") or [])
+        # Exclude Merkkipäiväpalvelu items (anpa_category.qcode == "5")
+        items = exclude_merkkipaivapalvelu_items(items)
         ag["items"] = items
 
     # Collect unique event IDs from all agendas


### PR DESCRIPTION
- It filters out any item where anpa_category contains an entry with qcode == "5" (Merkkipäiväpalvelu), and safely ignores missing/non-list anpa_category.
- Using it in enrich_related.py to exclude "Merkkipäiväpalvelu" items in "Lupaus" and "Kuvalupaus" templates

https://trello.com/c/uLLalcEk