### PR TITLE
[STT-1452] - Fix the STT "Autotranslate and publish" macro 

### DIFF
--- a/server/stt/macros/auto_translate_and_publish.py
+++ b/server/stt/macros/auto_translate_and_publish.py
@@ -52,8 +52,8 @@ async def auto_translate_and_publish(item, **kwargs):
         item["headline"] = get_headline_for_item(translated_item)
         html = get_body_html_for_item(translated_item, item)
         item["body_html"] = html
-        if item.get("_internal_destination"):
-            item.pop("_internal_destination", None)
+        internal_destination = kwargs.get("internal_destination")
+        if internal_destination:
             archive_service = get_resource_service("archive")
             extra_fields = [PUBLISH_SCHEDULE, SCHEDULE_SETTINGS]
             new_id = await archive_service.duplicate_item(

--- a/server/stt/macros/auto_translate_and_publish.py
+++ b/server/stt/macros/auto_translate_and_publish.py
@@ -67,8 +67,6 @@ async def auto_translate_and_publish(item, **kwargs):
         if item.get(ITEM_STATE) == CONTENT_STATE.PUBLISHED:
             return item
         return await auto_publish(item, **kwargs)
-    except StopDuplication:
-        raise
     except Exception as e:
         logger.error("Error during Auto Translate and Publish macro: %s", str(e))
         return item

--- a/server/stt/macros/auto_translate_and_publish.py
+++ b/server/stt/macros/auto_translate_and_publish.py
@@ -1,6 +1,12 @@
 from superdesk import get_resource_service
+from superdesk.errors import StopDuplication
 from superdesk.resource_fields import ID_FIELD
-from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
+from superdesk.metadata.item import (
+    ITEM_STATE,
+    CONTENT_STATE,
+    PUBLISH_SCHEDULE,
+    SCHEDULE_SETTINGS,
+)
 from .helpers.auto_translate_item import AutoTranslateItem
 from .helpers.getters import get_headline_for_item, get_body_html_for_item
 
@@ -46,7 +52,23 @@ async def auto_translate_and_publish(item, **kwargs):
         item["headline"] = get_headline_for_item(translated_item)
         html = get_body_html_for_item(translated_item, item)
         item["body_html"] = html
+        if item.get("_internal_destination"):
+            item.pop("_internal_destination", None)
+            archive_service = get_resource_service("archive")
+            extra_fields = [PUBLISH_SCHEDULE, SCHEDULE_SETTINGS]
+            new_id = await archive_service.duplicate_item(
+                item, state="routed", extra_fields=extra_fields
+            )
+            await get_resource_service("archive_publish").patch_async(
+                id=new_id,
+                updates={ITEM_STATE: CONTENT_STATE.PUBLISHED, "auto_publish": True},
+            )
+            raise StopDuplication()
+        if item.get(ITEM_STATE) == CONTENT_STATE.PUBLISHED:
+            return item
         return await auto_publish(item, **kwargs)
+    except StopDuplication:
+        raise
     except Exception as e:
         logger.error("Error during Auto Translate and Publish macro: %s", str(e))
         return item


### PR DESCRIPTION
### Purpose
This pr fixes issue with the STT "Autotranslate and publish" macro when triggered by internal routing. The issue was that the macro published the source item, then the internal-destination routing duplicated it, leaving the translated copy in `routed` state and sometimes triggering a second publish attempt which would cause an internal 412 error

### What has changed
- Detect internal-destination flow via a flag on the item and then duplicate the translated item to a routed copy and publish that duplicate.

### How to test
1. Have 2 Desks. Desk A and Desk B.
2. Ensure internal-destination routing is configured to Desk B with the incoming macro `auto_translate_and_publish_macro` in one of the stages.
3. Create a non-English story with headline + body like using the Pikaplus profile
4. Publish the story or use the “Send to” flow
5. Verify the routed copy in the Auto Translation desk is translated and published.

**Note**: 
- This change is tied to a change in superdesk-core in this [PR](https://github.com/superdesk/superdesk-core/pull/3144)
- The testing requires the right env variables for Google Translate

Resolves : [STT-1452](https://sofab.atlassian.net/browse/STT-1452)

[STT-1452]: https://sofab.atlassian.net/browse/STT-1452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ