### PR TITLE
[STT-1622] Embargo and Schedule info lost when doing the "Copy and send to Desk" action

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -73,6 +73,7 @@ module.exports = function (grunt) {
         sendAndDuplicate: {
           deskName: 'Deski',
           stageName: 'Incoming Stage',
+          preserveEmbargoAndSchedule: true,
         },
       },
       confirmDueDate: true /* confirm due date */,


### PR DESCRIPTION
### Purpose
This PR ensures that embargo, publish_schedule, and schedule_settings fields are preserved when duplicating content to a desk in the "Send and Duplicate" flow by setting the new client configuration to True

### What has changed
- Added `preserveEmbargoAndSchedule` optional boolean to `sendAndDuplicate` client configuration

### Steps to test
1. Configure `sendAndDuplicate.preserveEmbargoAndSchedule: true` in superdesk.config.js
2. Create a story on any desk and add embargo and publishing schedule dates
3. Save the story
4. Click the "Send and Duplicate" button (sends to the configured target desk, e.g., Deski)
5. Verify the duplicated story in the target desk has the same:
   - Embargo date
   - Publishing schedule date
   - Schedule settings (timezone)
6. Verify the original story retains its embargo and schedule information
7. Test regular "Duplicate To" flow - fields should NOT be preserved

Note: This PR is related to this [PR in superdesk-core](https://github.com/superdesk/superdesk-core/pull/3150), and [PR in superdesk-client-core](https://github.com/superdesk/superdesk-client-core/pull/5079)

Resolves: [STT-1622](https://sofab.atlassian.net/browse/STT-1622)

[STT-1622]: https://sofab.atlassian.net/browse/STT-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ