### PR TITLE
feat: Improve Newshub search filters and normalize fetched search items

### DIFF
--- a/client/stt/newshub/NewshubSearchController.ts
+++ b/client/stt/newshub/NewshubSearchController.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import _ from 'lodash';
 
 interface Subject {
   id?: string;
@@ -6,20 +6,12 @@ interface Subject {
   qcode?: string;
 }
 
-const META_VALUES_TO_CVS = [
-  "sttdepartment",
-  "sttgenre",
-  "sttsubj",
-  "stturgency",
-];
-
 export default class NewshubSearchController {
   periods: Subject[];
-  subjects: Subject[];
-  departments: Subject[];
-  urgencies: Subject[];
-  genres: Subject[];
-  cvs: any[];
+  categories: any;
+  genre: any;
+  urgency: any;
+  sttversions: any;
   desks: any;
   content: any;
   metadata: any;
@@ -32,24 +24,24 @@ export default class NewshubSearchController {
   params: any;
 
   static $inject: string[] = [
-    "$scope",
-    "$rootScope",
-    "vocabularies",
-    "api",
-    "desks",
-    "content",
-    "metadata",
-    "preferencesService",
+    '$scope',
+    '$rootScope',
+    'vocabularies',
+    'api',
+    'desks',
+    'content',
+    'metadata',
+    'preferencesService',
   ];
   constructor(
-    $scope,
-    $rootScope,
-    vocabularies,
-    api,
-    desks,
-    content,
-    metadata,
-    preferencesService
+    $scope: any,
+    $rootScope: any,
+    vocabularies: any,
+    api: any,
+    desks: any,
+    content: any,
+    metadata: any,
+    preferencesService: any,
   ) {
     this.$scope = $scope;
     this.$rootScope = $rootScope;
@@ -61,168 +53,48 @@ export default class NewshubSearchController {
     this.preferencesService = preferencesService;
     this.params = {};
 
+    this.$scope.params = this.$scope.params || {};
+    this.$scope.params.dates = this.$scope.params.dates || {};
+
     // Initialize static lists
     this.periods = [
-      { name: "Whenever", id: "" },
-      { name: "Last 24 hours", id: "day" },
-      { name: "Last week", id: "week" },
-      { name: "Last month", id: "month" },
-      { name: "Last year", id: "year" },
+      { name: 'Whenever', id: '' },
+      { name: 'Last 24 hours', id: 'day' },
+      { name: 'Last week', id: 'week' },
+      { name: 'Last month', id: 'month' },
+      { name: 'Last year', id: 'year' },
     ];
     desks.initialize();
     // Call the async initialization (fire-and-forget)
     this.initialize();
-
-    // metadata
-    //   .initialize()
-    //   .then(() => {
-    //     $scope.metadata = metadata.values;
-    //     console.log("metadata.values", metadata.values);
-    //     return preferencesService.get();
-    //   })
-    //   .then(this.setAvailableSttDepartments.bind(this))
-    //   .catch((error) => {
-    //     console.error("Error initializing metadata:", error);
-    //   });
-
-    // $scope.$watch(
-    //   () => this.params["sttsubj"],
-    //   (newVal, oldVal) => {
-    //     if (angular.isObject(newVal) && newVal.qcode) {
-    //       this.params["sttsubj"] = newVal.qcode;
-    //     }
-    //   }
-    // );
-
-    // $scope.$watch(
-    //   () => this.params["sttdepartment"],
-    //   (newVal, oldVal) => {
-    //     console.log("sttdepartment newVal", newVal);
-    //     if (angular.isObject(newVal) && newVal.qcode) {
-    //       this.params["sttdepartment"] = newVal.qcode;
-    //     }
-    //   }
-    // );
-
-    // $scope.$watch(
-    //   () => this.params["sttgenre"],
-    //   (newVal, oldVal) => {
-    //     if (angular.isObject(newVal) && newVal.qcode) {
-    //       this.params["sttgenre"] = newVal.qcode;
-    //     }
-    //   }
-    // );
-
-    // $scope.$watch(
-    //   () => this.params["stturgency"],
-    //   (newVal, oldVal) => {
-    //     if (angular.isObject(newVal) && newVal.qcode) {
-    //       this.params["stturgency"] = newVal.qcode;
-    //     }
-    //   }
-    // );
-
-    // Setup listeners (example shown)
-    // $rootScope.$on("vocabularies:created", (event, data) => {
-    //   api.find("vocabularies", data.vocabulary_id).then((cv) => {
-    //     this.cvs = this.cvs.concat([cv]);
-    //   });
-    // });
-    // $rootScope.$on("vocabularies:updated", (event, data) => {
-    //   api.find("vocabularies", data.vocabulary_id).then((cv) => {
-    //     this.cvs = this.cvs.map((_cv) => (_cv._id === cv._id ? cv : _cv));
-    //   });
-    // });
   }
-  /**
-   * Builds a list of categories available for selection in scope. Used by
-   * the "category" menu in the Authoring metadata section.
-   *
-   * @function setAvailableCategories
-   * @param {Object} prefs - user preferences setting, including the
-   *   preferred categories settings, among other things
-   */
-  // private setAvailableSttDepartments(prefs) {
-  //   var all, // all available categories
-  //     filtered,
-  //     // user's department preference settings , i.e. a map
-  //     // object (<department_code> --> true/false)
-  //     userPrefs;
 
-  //   all = this.metadata.values.sttdepartment || [];
-  //   console.log("prefs: ", prefs);
-  //   // userPrefs = prefs["sttdepartment:preferred"].selected;
-  //   filtered = _.filter(
-  //     all,
-  //     (dept) => _.isEmpty(userPrefs) || userPrefs[dept.qcode]
-  //   );
-  //   this.$scope.availableDepartments = _.sortBy(filtered, "name");
-  //   console.log(
-  //     "this.$scope.availableDepartments",
-  //     this.$scope.availableDepartments
-  //   );
-  // }
-  /**
-   * Builds a list of company_codes available for selection in scope. Used by
-   * the "company_codes" menu in the Authoring metadata section.
-   *
-   * @function setAvailableCompanyCodes
-   */
-  // private setAvailableCompanyCodes() {
-  //   var all, // all available company codes
-  //     assigned = {}, // company codes already assigned to the article
-  //     filtered,
-  //     itemCompanyCodes; // existing company codes assigned to the article
-
-  //   all = _.cloneDeep(this.metadata.values.company_codes || []);
-
-  //   all.forEach((companyCode) => {
-  //     companyCode.name = companyCode.name + " (" + companyCode.qcode + ")";
-  //   });
-
-  //   // gather article's existing company codes
-  //   itemCompanyCodes = this.$scope.item.company_codes || [];
-
-  //   itemCompanyCodes.forEach((companyCode) => {
-  //     assigned[companyCode.qcode] = true;
-  //   });
-
-  //   filtered = _.filter(all, (companyCode) => !assigned[companyCode.qcode]);
-
-  //   this.$scope.availableCompanyCodes = _.sortBy(filtered, "name");
-  // }
   private async initialize(): Promise<void> {
     try {
       const data = await this.vocabularies.getAllActiveVocabularies();
-      this.cvs = data.filter((cv) => META_VALUES_TO_CVS.includes(cv._id));
-      console.log("this.cvs", this.cvs);
-      const subjects = data.filter((cv) => cv._id === "sttsubj");
-      this.subjects = subjects.length > 0 ? subjects[0] : null;
-      const departments = data.filter((cv) => cv._id === "sttdepartment");
-      this.departments = departments.length > 0 ? departments[0] : null;
-      const urgencies = data.filter((cv) => cv._id === "stturgency");
-      this.urgencies = urgencies.length > 0 ? urgencies[0] : null;
-      const genres = data.filter((cv) => cv._id === "sttgenre");
-      this.genres = genres.length > 0 ? genres[0] : null;
-      console.log(
-        "Subjects, Departments, Urgencies, and Genres initialized successfully."
-      );
-      console.log("this.subjects", this.subjects);
-      console.log("this.departments", this.departments);
-      console.log("this.urgencies", this.urgencies);
-      console.log("this.genres", this.genres);
+
+      this.categories = this.getVocabulary(data, 'categories');
+      this.genre = this.getVocabulary(data, 'genre');
+      this.urgency = this.getVocabulary(data, 'urgency');
+      this.sttversions = this.getVocabulary(data, 'sttversion');
     } catch (error) {
-      console.error("Failed to initialize vocabularies: ", error);
+      console.error('Failed to initialize vocabularies: ', error);
     }
+  }
+
+  private getVocabulary(data: any[], vocabularyId: string): any {
+    const vocabulary = data.find((item: any) => item._id === vocabularyId);
+
+    return vocabulary || null;
   }
 }
 NewshubSearchController.$inject = [
-  "$scope",
-  "$rootScope",
-  "vocabularies",
-  "api",
-  "desks",
-  "content",
-  "metadata",
-  "preferencesService",
+  '$scope',
+  '$rootScope',
+  'vocabularies',
+  'api',
+  'desks',
+  'content',
+  'metadata',
+  'preferencesService',
 ];

--- a/client/stt/newshub/NewshubSearchController.ts
+++ b/client/stt/newshub/NewshubSearchController.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 interface Subject {
   id?: string;
   name: string;
@@ -88,13 +86,3 @@ export default class NewshubSearchController {
     return vocabulary || null;
   }
 }
-NewshubSearchController.$inject = [
-  '$scope',
-  '$rootScope',
-  'vocabularies',
-  'api',
-  'desks',
-  'content',
-  'metadata',
-  'preferencesService',
-];

--- a/client/stt/newshub/index.js
+++ b/client/stt/newshub/index.js
@@ -1,15 +1,15 @@
-import angular from "angular";
-import NewshubSearchController from "./NewshubSearchController";
+import angular from 'angular';
+import NewshubSearchController from './NewshubSearchController';
 
 export default angular
-  .module("stt.newshub", ["superdesk.apps.authoring.metadata"])
-  .controller("NewshubSearchController", NewshubSearchController)
+  .module('stt.newshub', ['superdesk.apps.authoring.metadata'])
+  .controller('NewshubSearchController', NewshubSearchController)
   .run([
-    "$templateCache",
+    '$templateCache',
     ($templateCache) => {
       $templateCache.put(
-        "search-panel-newshub.html",
-        require("./views/search-panel.html")
+        'search-panel-newshub.html',
+        require('./views/search-panel.html'),
       );
     },
   ]);

--- a/client/stt/newshub/views/search-panel.html
+++ b/client/stt/newshub/views/search-panel.html
@@ -6,30 +6,44 @@
             <option ng-repeat="period in searchPanel.periods" value="{{ period.id }}">{{ period.name }}</option>
         </select>
     </div>
-    <!-- add subjects -->
-    <!-- <div class="field">
-        <label class="search-label" translate>{{:: 'Subjects' | translate}}</label>
-        <select ng-model="searchPanel.params.subject">
-            <option ng-repeat="subject in searchPanel.subjects.items" value="{{ subject.qcode }}">{{ subject.name }}</option>
+
+    <div class="field">
+        <label class="search-label" translate>{{:: 'Osasto' | translate}}</label>
+        <select ng-model="params.categories">
+            <option value=""></option>
+            <option ng-repeat="item in searchPanel.categories.items" value="{{ item.qcode }}">{{ item.name }}</option>
         </select>
-    </div> -->
-    <!-- <div class="form__row" ng-repeat="cv in searchPanel.cvs track by cv._id">
-        <label class="form-label form__row-label" for="search-{{cv.display_name}}">
-            {{cv.display_name | translate}}
-        </label>
-        <div id="search-{{cv.display_name}}">
-            <div id="{{cv.display_name}}" sd-meta-terms
-                ng-model="searchPanel.params[cv._id]"
-                data-item="selecteditems"
-                data-field="{{cv._id}}"
-                data-unique="qcode"
-                data-list="cv.items"
-                data-reload-list="true"
-                data-header="true"
-                data-change="itemSearch(selecteditems, cv._id)"
-                ></div>
-        </div>
-    </div> -->
+    </div>
+
+    <div class="field">
+        <label class="search-label" translate>{{:: 'Juttutyyppi' | translate}}</label>
+        <select ng-model="params.genre">
+            <option value=""></option>
+            <option ng-repeat="item in searchPanel.genre.items" value="{{ item.qcode }}">{{ item.name }}</option>
+        </select>
+    </div>
+
+    <div class="field">
+        <label class="search-label" translate>{{:: 'Versiotyyppi' | translate}}</label>
+        <select ng-model="params.sttversion">
+            <option value=""></option>
+            <option ng-repeat="item in searchPanel.sttversions.items" value="{{ item.qcode }}">{{ item.name }}</option>
+        </select>
+    </div>
+
+    <div class="field">
+        <label class="search-label" translate>{{:: 'Prio' | translate}}</label>
+        <select ng-model="params.urgency">
+            <option value=""></option>
+            <option ng-repeat="item in searchPanel.urgency.items" value="{{ item.qcode }}">{{ item.name }}</option>
+        </select>
+    </div>
+
+    <div class="field">
+        <label class="search-label" translate>{{:: 'Tekijä' | translate}}</label>
+        <input type="text" ng-model="params.byline" />
+    </div>
+
     <div class="form__row form__row--flex form__row--small-padding">
         <div class="form__row-item">
             <label class="form-label" translate>{{:: 'From' | translate}}</label>

--- a/server/stt/search_providers/newshub.py
+++ b/server/stt/search_providers/newshub.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import arrow
 import aiohttp
 from aiohttp.client_exceptions import ClientResponseError
+from dateutil import parser as dtparse
 
 import superdesk
 from superdesk.core import get_config
@@ -83,18 +84,48 @@ class NewshubSearchProvider(superdesk.SearchProvider):
 
         return guid
 
+    def _normalize_timestamp(self, value) -> datetime | None:
+        if not value:
+            return None
+
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=timezone.utc)
+            return value.astimezone(timezone.utc)
+
+        try:
+            parsed = dtparse.parse(str(value))
+        except (TypeError, ValueError, OverflowError) as exc:
+            logger.warning("Failed to parse timestamp %r: %s", value, exc)
+            return None
+
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+
+        return parsed.astimezone(timezone.utc)
+
+    def _escape_query_phrase(self, value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
     def extend_data_item(self, item: dict) -> dict:
         # Shape results like a regular external text item so the search UI can
         # resolve actions and preview behavior consistently.
         now = datetime.now(timezone.utc)
+        firstcreated = self._normalize_timestamp(item.get("firstcreated"))
+        versioncreated = self._normalize_timestamp(item.get("versioncreated"))
+
+        if firstcreated is None:
+            firstcreated = versioncreated or now
+        if versioncreated is None:
+            versioncreated = firstcreated or now
 
         item["_type"] = "externalsource"
         item["type"] = "text"
         item["mimetype"] = "application/superdesk.item.text"
         item.setdefault("state", "published")
         item.setdefault("pubstatus", "usable")
-        item.setdefault("firstcreated", item.get("versioncreated") or now)
-        item.setdefault("versioncreated", item.get("firstcreated") or now)
+        item["firstcreated"] = firstcreated
+        item["versioncreated"] = versioncreated
         item["_fetchable"] = True
         item["search_provider"] = self.provider.get("search_provider", "newshub")
         item["fetch_endpoint"] = "search_providers_proxy"
@@ -226,7 +257,8 @@ class NewshubSearchProvider(superdesk.SearchProvider):
         if byline:
             byline = byline.strip()
             if byline and not str(search_text).startswith('_id:"'):
-                search_text = f"{search_text} {byline}".strip()
+                safe_byline = self._escape_query_phrase(byline)
+                search_text = f'{search_text} "{safe_byline}"'.strip()
 
         return search_text or None
 

--- a/server/stt/search_providers/newshub.py
+++ b/server/stt/search_providers/newshub.py
@@ -1,5 +1,6 @@
 from urllib.parse import urljoin
 import logging
+from datetime import datetime, timezone
 
 import arrow
 import aiohttp
@@ -27,7 +28,7 @@ class NewshubListCursor(ListCursor):
 class NewshubSearchProvider(superdesk.SearchProvider):
     label = "Newshub"
     # TODO: set the base_url to the production URL when ready
-    base_url = "https://stt-uat.newshub.pro/newsapi/v1/"
+    base_url = "https://stt-next.newshub.pro/newsapi/v1/"
     api_token = None
     search_endpoint = "news/search"
     items_field = "_items"
@@ -38,6 +39,28 @@ class NewshubSearchProvider(superdesk.SearchProvider):
         "month": {"months": -1},
         "year": {"years": -1},
     }
+    INCLUDE_FIELDS = ",".join(
+        [
+            "type",
+            "urgency",
+            "priority",
+            "language",
+            "description_html",
+            "located",
+            "keywords",
+            "source",
+            "subject",
+            "place",
+            "wordcount",
+            "charcount",
+            "body_html",
+            "readtime",
+            "profile",
+            "service",
+            "genre",
+            "headline",
+        ]
+    )
 
     def __init__(self, provider):
         logger.info(f"Newshub search provider: init {provider}")
@@ -48,9 +71,38 @@ class NewshubSearchProvider(superdesk.SearchProvider):
     def url(self, resource):
         return urljoin(self.base_url, resource.lstrip("/"))
 
+    def _get_fetch_guid(self, item: dict) -> str | None:
+        guid = item.get("guid") or item.get("_id")
+
+        if guid is None:
+            return None
+
+        guid = str(guid)
+        if guid.startswith("urn:newsml:stt.fi::"):
+            return guid.split("::", 1)[1]
+
+        return guid
+
     def extend_data_item(self, item: dict) -> dict:
-        # add "_fetchable": True, to the item
+        # Shape results like a regular external text item so the search UI can
+        # resolve actions and preview behavior consistently.
+        now = datetime.now(timezone.utc)
+
+        item["_type"] = "externalsource"
+        item["type"] = "text"
+        item["mimetype"] = "application/superdesk.item.text"
+        item.setdefault("state", "published")
+        item.setdefault("pubstatus", "usable")
+        item.setdefault("firstcreated", item.get("versioncreated") or now)
+        item.setdefault("versioncreated", item.get("firstcreated") or now)
         item["_fetchable"] = True
+        item["search_provider"] = self.provider.get("search_provider", "newshub")
+        item["fetch_endpoint"] = "search_providers_proxy"
+
+        fetch_guid = self._get_fetch_guid(item)
+        if fetch_guid:
+            item.setdefault("guid", fetch_guid)
+
         return item
 
     async def find_async(
@@ -69,6 +121,7 @@ class NewshubSearchProvider(superdesk.SearchProvider):
             "page_size": page_size,
             "page": int(query.get("from", 0) / page_size) + 1,
             "timezone": get_config(str, "DEFAULT_TIMEZONE"),
+            "include_fields": self.INCLUDE_FIELDS,
         }
         if params:
             dates = params.get("dates", {})
@@ -86,10 +139,14 @@ class NewshubSearchProvider(superdesk.SearchProvider):
                 api_params["urgency"] = params["urgency"]
             if params.get("genre"):
                 api_params["genre"] = params["genre"]
-            if params.get("subject"):
-                api_params["subject"] = params["subject"]
+            if params.get("categories"):
+                api_params["service"] = params["categories"]
+            if params.get("sttversion") or params.get("subject"):
+                api_params["subject"] = params.get("sttversion") or params.get(
+                    "subject"
+                )
 
-        api_params["q"] = self.get_search_text(query)
+        api_params["q"] = self.get_search_text(query, params)
 
         logger.info(f"API params: {api_params}")
 
@@ -118,19 +175,24 @@ class NewshubSearchProvider(superdesk.SearchProvider):
         self, session: aiohttp.ClientSession, item_id: str
     ) -> dict | None:
         logger.info(f"Fetch item: {item_id}")
+        search_id = item_id
+        if not str(search_id).startswith("urn:"):
+            search_id = f"urn:newsml:stt.fi::{item_id}"
+
         api_params = {
-            # this should be like _id:"urn:newsml:stt.fi::106858998"
-            "q": f'_id:"urn:newsml:stt.fi::{item_id}"',
+            "q": f'_id:"{search_id}"',
+            "include_fields": self.INCLUDE_FIELDS,
         }
         try:
             data = await self.api_get(session, self.search_endpoint, api_params)
-            if not data:
+            items = data.get(self.items_field, []) if data else []
+            if not items:
                 logger.warning("No item found.")
                 return None
         except ClientResponseError as e:
             logger.error(f"Request failed: {e}")
             return None
-        return self.extend_data_item(data)
+        return self.extend_data_item(items[0])
 
     async def api_get(
         self, session: aiohttp.ClientSession, endpoint: str, params: dict
@@ -145,7 +207,7 @@ class NewshubSearchProvider(superdesk.SearchProvider):
             resp.raise_for_status()
             return await resp.json()
 
-    def get_search_text(self, query: dict) -> str | None:
+    def get_search_text(self, query: dict, params: dict | None = None) -> str | None:
         try:
             search_text = query["query"]["filtered"]["query"]["query_string"]["query"]
         except KeyError:
@@ -159,6 +221,13 @@ class NewshubSearchProvider(superdesk.SearchProvider):
                         break
         except KeyError:
             pass
+
+        byline = (params or {}).get("byline")
+        if byline:
+            byline = byline.strip()
+            if byline and not str(search_text).startswith('_id:"'):
+                search_text = f"{search_text} {byline}".strip()
+
         return search_text or None
 
     def _get_period(self, period: str) -> dict[str, str]:

--- a/server/tests/newshub_search_provider_test.py
+++ b/server/tests/newshub_search_provider_test.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timezone
+import unittest
+
+from stt.search_providers.newshub import NewshubSearchProvider
+
+
+class NewshubSearchProviderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.provider = NewshubSearchProvider.__new__(NewshubSearchProvider)
+        self.provider.provider = {
+            "config": {"password": "token"},
+            "search_provider": "newshub",
+        }
+
+    def test_extend_data_item_normalizes_string_timestamps(self):
+        item = {
+            "_id": "urn:newsml:stt.fi::12345",
+            "firstcreated": "2026-03-09T12:30:00+02:00",
+            "versioncreated": "2026-03-09T10:45:00Z",
+        }
+
+        extended = self.provider.extend_data_item(item)
+
+        self.assertIsInstance(extended["firstcreated"], datetime)
+        self.assertIsInstance(extended["versioncreated"], datetime)
+        self.assertEqual(extended["firstcreated"].tzinfo, timezone.utc)
+        self.assertEqual(extended["versioncreated"].tzinfo, timezone.utc)
+        self.assertEqual(
+            extended["firstcreated"], datetime(2026, 3, 9, 10, 30, tzinfo=timezone.utc)
+        )
+        self.assertEqual(
+            extended["versioncreated"],
+            datetime(2026, 3, 9, 10, 45, tzinfo=timezone.utc),
+        )
+
+    def test_extend_data_item_defaults_from_normalized_versioncreated(self):
+        item = {
+            "_id": "urn:newsml:stt.fi::12345",
+            "versioncreated": "2026-03-09T10:45:00+02:00",
+        }
+
+        extended = self.provider.extend_data_item(item)
+
+        self.assertEqual(
+            extended["firstcreated"], datetime(2026, 3, 9, 8, 45, tzinfo=timezone.utc)
+        )
+        self.assertEqual(extended["firstcreated"], extended["versioncreated"])
+
+    def test_extend_data_item_replaces_invalid_timestamp_with_default_datetime(self):
+        item = {
+            "_id": "urn:newsml:stt.fi::12345",
+            "firstcreated": "not-a-date",
+        }
+
+        extended = self.provider.extend_data_item(item)
+
+        self.assertIsInstance(extended["firstcreated"], datetime)
+        self.assertIsInstance(extended["versioncreated"], datetime)
+        self.assertEqual(extended["firstcreated"].tzinfo, timezone.utc)
+        self.assertEqual(extended["versioncreated"].tzinfo, timezone.utc)
+
+    def test_get_search_text_quotes_and_escapes_byline(self):
+        query = {
+            "query": {
+                "filtered": {
+                    "query": {"query_string": {"query": "economy"}},
+                }
+            }
+        }
+
+        search_text = self.provider.get_search_text(
+            query,
+            {"byline": 'Jane "JJ" Doe: Bureau\\Desk'},
+        )
+
+        self.assertEqual(search_text, 'economy "Jane \\"JJ\\" Doe: Bureau\\\\Desk"')
+
+    def test_get_search_text_does_not_append_byline_to_id_lookup(self):
+        query = {
+            "query": {
+                "filtered": {
+                    "filter": {
+                        "or": [
+                            {
+                                "term": {
+                                    "_id": "urn:newsml:stt.fi::12345",
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+
+        search_text = self.provider.get_search_text(query, {"byline": 'Jane "JJ" Doe'})
+
+        self.assertEqual(search_text, '_id:"urn:newsml:stt.fi::12345"')


### PR DESCRIPTION
Replace the old Newshub filter wiring with explicit single-select controls for service, genre, version type and urgency, and add a free-text byline field in the custom search panel.

Update the Newshub search provider to:
- request a richer field set via include_fields
- map client filters to the API fields used by news/search (categories -> service, sttversion -> subject, urgency, genre)
- append byline text to the free-text query (it seems that `/news/search` endpoint doesn't support `byline` / `author` search param directly, it doesn't also return that `byline` / `author` data)
- normalize search results as externalsource text items so built-in Fetch and Fetch To actions work correctly
- fetch items by _id search and return the first matching result