### PR TITLE
Feat/paivalista tweaks

### DIFF
--- a/server/stt/paivalista_export/common.py
+++ b/server/stt/paivalista_export/common.py
@@ -24,8 +24,14 @@ def include_only_mediatilaisuudet_items(
     return filtered_items
 
 
+def exclude_non_published_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    # exclude items that have "pubstatus" not equal to "usable"
+    return [item for item in items if item.get("pubstatus") == "usable"]
+
+
 def format_paivalista_for_export(items):
     rows = items or []
+    rows = exclude_non_published_items(rows)
     rows = include_only_mediatilaisuudet_items(rows)
 
     return {"rows": rows}

--- a/server/stt/paivalista_export/common.py
+++ b/server/stt/paivalista_export/common.py
@@ -24,14 +24,14 @@ def include_only_mediatilaisuudet_items(
     return filtered_items
 
 
-def exclude_non_published_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    # exclude items that have "pubstatus" not equal to "usable"
-    return [item for item in items if item.get("pubstatus") == "usable"]
+def include_only_published_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    # include only items in states that represent published events
+    return [item for item in items if item.get("state") in ("scheduled", "rescheduled")]
 
 
 def format_paivalista_for_export(items):
     rows = items or []
-    rows = exclude_non_published_items(rows)
+    rows = include_only_published_items(rows)
     rows = include_only_mediatilaisuudet_items(rows)
 
     return {"rows": rows}

--- a/server/templates/paivalista_events_template.html
+++ b/server/templates/paivalista_events_template.html
@@ -15,6 +15,13 @@
     {%- endif -%}
 {%- endmacro %}
 
+{% macro ensure_sentence_end(text) -%}
+    {%- set value = text | trim -%}
+    {%- if value -%}
+        {{- value if value.endswith('.') or value.endswith('?') or value.endswith('!') else value ~ '.' -}}
+    {%- endif -%}
+{%- endmacro %}
+
 {#-- MAIN LOOP — sort first, then print a <h3> when the day changes --#}
 {% set ns = namespace(cur='') %}
 {% for item in rows | sort(attribute='dates.start') %}
@@ -29,9 +36,18 @@
         <p>{{ item.dates.start | fi_time }} {{ item.name }}</p>
     {% endif %}
 
-    {# Short definition --------------------------------------------------- #}
-    {% if item.definition_short %}
-        <p>{{ item.definition_short }}</p>
+    {# Short definition + invitation details ------------------------------ #}
+    {% set text_ns = namespace(parts=[]) %}
+    {% set definition_short = item.definition_short | trim if item.definition_short is defined and item.definition_short else '' %}
+    {% set invitation_details = item.invitation_details | trim if item.invitation_details is defined and item.invitation_details else '' %}
+    {% if definition_short %}
+        {% set _ = text_ns.parts.append(ensure_sentence_end(definition_short)) %}
+    {% endif %}
+    {% if invitation_details %}
+        {% set _ = text_ns.parts.append(ensure_sentence_end(invitation_details)) %}
+    {% endif %}
+    {% if text_ns.parts %}
+        <p>{{ text_ns.parts | join(' ') }}</p>
     {% endif %}
 
     {# Location ----------------------------------------------------------- #}


### PR DESCRIPTION
feat: Combine paivalista intro text and normalize punctuation
    
    Render definition_short and invitation_details as a single paragraph in
    paivalista_events_template.html. Ensure each text fragment ends with
    proper sentence punctuation, and include invitation_details even when
    definition_short is missing.

feat: exclude event items that are not published