### PR TITLE
STT-1583: Enable retention of coverage status and assignee details when duplicating planning items

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -389,3 +389,7 @@ if SAML_PATH and os.path.exists(SAML_PATH) and not strtobool(env("SUPERDESK_AUTH
 PLANNING_JSON_EXCLUDE_ASSIGNEE_FIELDS = ["desk"]
 
 ALLOW_UPDATING_EMBARGOED_ITEMS = True
+
+# Retain coverage status and assignee details when duplicating planning items
+PLANNING_DUPLICATE_RETAIN_COVERAGE_STATUS = True
+PLANNING_DUPLICATE_RETAIN_ASSIGNEE_DETAILS = True


### PR DESCRIPTION
### Purpose
This PR sets both `PLANNING_DUPLICATE_RETAIN_COVERAGE_STATUS` and `PLANNING_DUPLICATE_RETAIN_ASSIGNEE_DETAILS` to True for STT 

This works together with some change in superdesk-planning in this [PR](https://github.com/superdesk/superdesk-planning/pull/2771)

Resolves: [STT-1583](https://sofab.atlassian.net/browse/STT-1583)

[STT-1583]: https://sofab.atlassian.net/browse/STT-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ