### PR TITLE
tweak dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,19 @@ updates:
     schedule:
       interval: "daily"
 
+  # only update direct dependencies on the next branch
   - package-ecosystem: "npm"
     directory: "/client"
     target-branch: "next"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "direct"
 
   - package-ecosystem: "pip"
     directory: "/server"
     target-branch: "next"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "direct"


### PR DESCRIPTION
only update direct dependencies on next
to keep it more stable.