### PR TITLE
feat: Include previous evening corrections in oikaisut export

### DIFF
--- a/server/stt/helpers/mongo_helpers.py
+++ b/server/stt/helpers/mongo_helpers.py
@@ -1,6 +1,7 @@
 """Shared helpers for querying Superdesk resources with optional projection support."""
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from superdesk import get_resource_service
@@ -294,3 +295,107 @@ def get_published_items_by_planning_id_and_genre_qcodes(
     # Stable ordering for exports/UI usage: newest first when the field exists.
     items.sort(key=lambda item: (item or {}).get("versioncreated") or "", reverse=True)
     return items
+
+
+def get_planning_items_with_published_corrections_between(
+    start_dt: datetime,
+    end_dt: datetime,
+    projection: Optional[Dict[str, int]] = None,
+) -> List[Dict[str, Any]]:
+    """Return planning items linked to late published oikaisu/korjaus content.
+
+    The relation is resolved through:
+
+        published.item_id
+        -> delivery.item_id
+        -> delivery.planning_id
+        -> planning._id
+
+    Only published items whose ``firstpublished`` value is within the half-open
+    interval ``[start_dt, end_dt)`` are considered.
+    Matching published items must also satisfy the export rules for this feed:
+    either ``state == 'corrected'`` or ``genre.qcode == 'sttgenre:11'``, and
+    ``profile != 'nettiuutinen'``.
+    """
+
+    if not start_dt or not end_dt or start_dt >= end_dt:
+        return []
+
+    try:
+        async_app = get_current_async_app()
+        collection = async_app.wsgi.data.get_mongo_collection("published")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            (
+                "Unable to access published Mongo collection "
+                "via service/driver "
+                "(%s: %s)"
+            ),
+            exc.__class__.__name__,
+            exc,
+        )
+        return []
+
+    pipeline = [
+        {
+            "$match": {
+                "firstpublished": {"$gte": start_dt, "$lt": end_dt},
+                "$or": [
+                    {"state": "corrected"},
+                    {"genre.qcode": "sttgenre:11"},
+                ],
+                "profile": {"$ne": "nettiuutinen"},
+            }
+        },
+        {"$project": {"item_id": 1, "_id": 0}},
+        {
+            "$lookup": {
+                "from": "delivery",
+                "let": {"published_item_id": "$item_id"},
+                "pipeline": [
+                    {
+                        "$match": {
+                            "$expr": {
+                                "$and": [
+                                    {
+                                        "$eq": [
+                                            "$item_id",
+                                            "$$published_item_id",
+                                        ]
+                                    },
+                                    {"$eq": ["$item_state", "published"]},
+                                ]
+                            }
+                        }
+                    },
+                    {"$project": {"planning_id": 1, "_id": 0}},
+                ],
+                "as": "deliveries",
+            }
+        },
+        {"$unwind": "$deliveries"},
+        {"$group": {"_id": "$deliveries.planning_id"}},
+    ]
+
+    try:
+        planning_ids = [
+            doc.get("_id")
+            for doc in collection.aggregate(pipeline)
+            if isinstance(doc, dict) and doc.get("_id")
+        ]
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            ("Error aggregating planning ids for published corrections " "(%s: %s)"),
+            exc.__class__.__name__,
+            exc,
+        )
+        return []
+
+    if not planning_ids:
+        return []
+
+    return find_many(
+        "planning",
+        {"_id": {"$in": planning_ids}},
+        projection=projection,
+    )

--- a/server/stt/oikaisut_korjaukset_export/enrich_items.py
+++ b/server/stt/oikaisut_korjaukset_export/enrich_items.py
@@ -1,10 +1,90 @@
-from typing import Dict, List, Any
+from datetime import datetime, time, timedelta, timezone
+from typing import Dict, List, Any, Optional, Tuple
 import logging
+from zoneinfo import ZoneInfo
 
-from stt.helpers.mongo_helpers import find_many
+from stt.constants import STT_TIMEZONE
+from stt.helpers.mongo_helpers import (
+    find_many,
+    get_planning_items_with_published_corrections_between,
+)
 from stt.helpers.template_helpers import exclude_drafts
 
 logger = logging.getLogger(__name__)
+
+_HELSINKI = ZoneInfo(STT_TIMEZONE)
+
+
+def _get_previous_day_evening_window_utc(
+    now: Optional[datetime] = None,
+) -> Tuple[datetime, datetime]:
+    """Return the previous day's 20:00-00:00 Helsinki window in UTC."""
+
+    current_time = now
+    if current_time is None:
+        current_time = datetime.now(timezone.utc)
+    elif current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    else:
+        current_time = current_time.astimezone(timezone.utc)
+
+    now_local = current_time.astimezone(_HELSINKI)
+    today_local = now_local.date()
+    previous_day_local = today_local - timedelta(days=1)
+
+    start_local = datetime.combine(
+        previous_day_local,
+        time(20, 0),
+        tzinfo=_HELSINKI,
+    )
+    end_local = datetime.combine(today_local, time.min, tzinfo=_HELSINKI)
+    return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def _merge_unique_items_by_id(
+    items: List[Dict[str, Any]],
+    extra_items: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Append extra planning items while preserving order and uniqueness."""
+
+    merged = list(items or [])
+    seen_ids = {
+        str(item.get("_id"))
+        for item in merged
+        if isinstance(item, dict) and item.get("_id")
+    }
+
+    for item in extra_items or []:
+        if not isinstance(item, dict):
+            continue
+        item_id = item.get("_id")
+        if not item_id:
+            merged.append(item)
+            continue
+        normalized_item_id = str(item_id)
+        if normalized_item_id in seen_ids:
+            continue
+        seen_ids.add(normalized_item_id)
+        merged.append(item)
+
+    return merged
+
+
+def _get_previous_day_evening_items() -> List[Dict[str, Any]]:
+    start_dt, end_dt = _get_previous_day_evening_window_utc()
+    return get_planning_items_with_published_corrections_between(
+        start_dt,
+        end_dt,
+        projection={
+            "_id": 1,
+            "anpa_category": 1,
+            "internal_coverages": 1,
+            "planning_date": 1,
+            "priority": 1,
+            "slugline": 1,
+            "state": 1,
+        },
+    )
 
 
 def _is_oikaisu(item: Dict[str, Any]) -> bool:
@@ -38,12 +118,14 @@ def _get_related_corrected_published_items(planning_id: str) -> List[Dict[str, A
         {"planning_id": planning_id, "item_state": "published"},
         projection={"item_id": 1, "_id": 0},
     )
-    # then loop through delivery results and get full items from "published" collection by matching item_id
+    # then loop through delivery results and get full items from
+    # "published" collection by matching item_id
     published_items = []
     for delivery in deliveries:
         item_id = delivery.get("item_id")
         if item_id:
-            # include only items that have state "corrected" (Korjaus) or genre.qcode "sttgenre:11" (Oikaisu)
+            # include only items that have state "corrected" (Korjaus) or
+            # genre.qcode "sttgenre:11" (Oikaisu)
             items = find_many(
                 "published",
                 {
@@ -77,7 +159,8 @@ def _get_related_corrected_published_items(planning_id: str) -> List[Dict[str, A
                 # add all found items to published_items
                 published_items.extend(items)
 
-    # If there is at least one oikaisu for this planning_id, ignore korjaus items.
+    # If there is at least one oikaisu for this planning_id,
+    # ignore korjaus items.
     if any(_is_oikaisu(item) for item in published_items):
         published_items = [
             item for item in published_items if item.get("state") != "corrected"
@@ -94,7 +177,8 @@ def _enrich_item(item: Dict[str, Any]) -> Dict[str, Any]:
     related_items = _get_related_corrected_published_items(planning_id)
     if related_items:
         item["related_corrected_published_items"] = related_items
-        # if item has "internal_coverages" field, we can remove it to reduce output size
+        # if item has "internal_coverages" field,
+        # we can remove it to reduce output size
         if "internal_coverages" in item:
             del item["internal_coverages"]
     return item
@@ -108,11 +192,13 @@ def _group_items_by_type(
     # exclude draft items
     items = exclude_drafts(items)
     for item in items:
-        # enrich item so we can check if it has related corrected published items
+        # enrich item so we can check if it has
+        # related corrected published items
         item = _enrich_item(item)
         # loop item.related_corrected_published_items and check for "state"
         # if state is "corrected" then it should be put to "korjaukset" array
-        # if state is not "corrected", then it should be put to "oikaisut" array
+        # if state is not "corrected", then it should be put
+        # to "oikaisut" array
         related_items = item.get("related_corrected_published_items", [])
         item_without_related_corrected_published_items = {
             k: v for k, v in item.items() if k != "related_corrected_published_items"
@@ -120,14 +206,16 @@ def _group_items_by_type(
         for related_item in related_items:
             state = related_item.get("state")
             if state == "corrected":
-                # add item_without_related_corrected_published_items to corrected_item and then add related_item to it
+                # add item_without_related_corrected_published_items to
+                # corrected_item and then add related_item to it
                 corrected_item = {
                     **item_without_related_corrected_published_items,
                     "corrected_published_item": related_item,
                 }
                 korjaukset.append(corrected_item)
             else:
-                # add item_without_related_corrected_published_items to corrected_item and then add related_item to it
+                # add item_without_related_corrected_published_items to
+                # corrected_item and then add related_item to it
                 corrected_item = {
                     **item_without_related_corrected_published_items,
                     "corrected_published_item": related_item,
@@ -150,6 +238,7 @@ def enrich_oikaisut_korjaukset_for_export(
         Dict[str, List[Dict[str, Any]]]: Dictionary with two keys: oikaisut and korjaukset.
     """
     rows = items or []
+    rows = _merge_unique_items_by_id(rows, _get_previous_day_evening_items())
     if not rows:
         return {"oikaisut": [], "korjaukset": []}
     rows_grouped = _group_items_by_type(rows)

--- a/server/stt/oikaisut_korjaukset_export/enrich_items.py
+++ b/server/stt/oikaisut_korjaukset_export/enrich_items.py
@@ -1,7 +1,9 @@
-from datetime import datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Dict, List, Any, Optional, Tuple
 import logging
 from zoneinfo import ZoneInfo
+
+from dateutil import parser
 
 from stt.constants import STT_TIMEZONE
 from stt.helpers.mongo_helpers import (
@@ -70,8 +72,52 @@ def _merge_unique_items_by_id(
     return merged
 
 
-def _get_previous_day_evening_items() -> List[Dict[str, Any]]:
-    start_dt, end_dt = _get_previous_day_evening_window_utc()
+def _get_reference_datetime_from_items(
+    items: List[Dict[str, Any]],
+) -> Optional[datetime]:
+    """Return the latest valid planning_date from items as an aware UTC datetime."""
+
+    planning_datetimes: List[datetime] = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        planning_date = item.get("planning_date")
+        parsed = _parse_planning_date(planning_date)
+        if parsed is not None:
+            planning_datetimes.append(parsed)
+
+    if not planning_datetimes:
+        return None
+
+    return max(planning_datetimes)
+
+
+def _parse_planning_date(value: Any) -> Optional[datetime]:
+    """Parse a planning_date value into an aware UTC datetime."""
+
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, date):
+        parsed = datetime.combine(value, time.min, tzinfo=_HELSINKI)
+    elif isinstance(value, str):
+        try:
+            parsed = parser.isoparse(value)
+        except (TypeError, ValueError):
+            return None
+    else:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_HELSINKI)
+
+    return parsed.astimezone(timezone.utc)
+
+
+def _get_previous_day_evening_items(
+    items: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    reference_dt = _get_reference_datetime_from_items(items)
+    start_dt, end_dt = _get_previous_day_evening_window_utc(reference_dt)
     return get_planning_items_with_published_corrections_between(
         start_dt,
         end_dt,
@@ -238,7 +284,7 @@ def enrich_oikaisut_korjaukset_for_export(
         Dict[str, List[Dict[str, Any]]]: Dictionary with two keys: oikaisut and korjaukset.
     """
     rows = items or []
-    rows = _merge_unique_items_by_id(rows, _get_previous_day_evening_items())
+    rows = _merge_unique_items_by_id(rows, _get_previous_day_evening_items(rows))
     if not rows:
         return {"oikaisut": [], "korjaukset": []}
     rows_grouped = _group_items_by_type(rows)

--- a/server/tests/oikaisut_korjaukset_export_test.py
+++ b/server/tests/oikaisut_korjaukset_export_test.py
@@ -10,6 +10,20 @@ _PREVIOUS_DAY_EVENING_ITEMS_PATCH = (
 
 
 class OikaisutKorjauksetExportTestCase(unittest.TestCase):
+    def test_reference_datetime_uses_latest_planning_date(self):
+        reference_dt = enrich_items._get_reference_datetime_from_items(
+            [
+                {"planning_date": "2026-01-14T00:00:00+0000"},
+                {"planning_date": datetime(2026, 1, 15, 0, 0, 0)},
+                {"planning_date": "invalid"},
+            ]
+        )
+
+        self.assertEqual(
+            datetime(2026, 1, 14, 22, 0, 0, tzinfo=timezone.utc),
+            reference_dt,
+        )
+
     def test_previous_day_evening_window_utc_in_winter(self):
         now = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
@@ -57,6 +71,7 @@ class OikaisutKorjauksetExportTestCase(unittest.TestCase):
 
         enrich_items.enrich_oikaisut_korjaukset_for_export(today_items)
 
+        mock_get_previous_day_evening_items.assert_called_once_with(today_items)
         mock_group_items_by_type.assert_called_once_with(
             [{"_id": "today-1"}, {"_id": "late-1"}]
         )
@@ -76,11 +91,40 @@ class OikaisutKorjauksetExportTestCase(unittest.TestCase):
 
         result = enrich_items.enrich_oikaisut_korjaukset_for_export([])
 
+        mock_get_previous_day_evening_items.assert_called_once_with([])
         self.assertEqual(
             {"oikaisut": [{"_id": "late-1"}], "korjaukset": []},
             result,
         )
         mock_group_items_by_type.assert_called_once_with([{"_id": "late-1"}])
+
+    @patch(
+        "stt.oikaisut_korjaukset_export.enrich_items."
+        "get_planning_items_with_published_corrections_between"
+    )
+    def test_previous_day_evening_items_use_reference_date_from_rows(
+        self,
+        mock_get_planning_items,
+    ):
+        mock_get_planning_items.return_value = []
+
+        enrich_items._get_previous_day_evening_items(
+            [{"planning_date": "2026-01-15T00:00:00+0000"}]
+        )
+
+        mock_get_planning_items.assert_called_once_with(
+            datetime(2026, 1, 14, 18, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 1, 14, 22, 0, 0, tzinfo=timezone.utc),
+            projection={
+                "_id": 1,
+                "anpa_category": 1,
+                "internal_coverages": 1,
+                "planning_date": 1,
+                "priority": 1,
+                "slugline": 1,
+                "state": 1,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/server/tests/oikaisut_korjaukset_export_test.py
+++ b/server/tests/oikaisut_korjaukset_export_test.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timezone
+import unittest
+from unittest.mock import patch
+
+from stt.oikaisut_korjaukset_export import enrich_items
+
+_PREVIOUS_DAY_EVENING_ITEMS_PATCH = (
+    "stt.oikaisut_korjaukset_export.enrich_items." "_get_previous_day_evening_items"
+)
+
+
+class OikaisutKorjauksetExportTestCase(unittest.TestCase):
+    def test_previous_day_evening_window_utc_in_winter(self):
+        now = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        start_dt, end_dt = enrich_items._get_previous_day_evening_window_utc(now)
+
+        self.assertEqual(
+            datetime(2026, 1, 14, 18, 0, 0, tzinfo=timezone.utc),
+            start_dt,
+        )
+        self.assertEqual(
+            datetime(2026, 1, 14, 22, 0, 0, tzinfo=timezone.utc),
+            end_dt,
+        )
+
+    def test_previous_day_evening_window_utc_in_summer(self):
+        now = datetime(2026, 7, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        start_dt, end_dt = enrich_items._get_previous_day_evening_window_utc(now)
+
+        self.assertEqual(
+            datetime(2026, 7, 14, 17, 0, 0, tzinfo=timezone.utc),
+            start_dt,
+        )
+        self.assertEqual(
+            datetime(2026, 7, 14, 21, 0, 0, tzinfo=timezone.utc),
+            end_dt,
+        )
+
+    @patch("stt.oikaisut_korjaukset_export.enrich_items._group_items_by_type")
+    @patch(_PREVIOUS_DAY_EVENING_ITEMS_PATCH)
+    def test_enrich_merges_previous_day_items_without_duplicates(
+        self,
+        mock_get_previous_day_evening_items,
+        mock_group_items_by_type,
+    ):
+        today_items = [{"_id": "today-1"}]
+        mock_get_previous_day_evening_items.return_value = [
+            {"_id": "today-1"},
+            {"_id": "late-1"},
+        ]
+        mock_group_items_by_type.return_value = {
+            "oikaisut": [],
+            "korjaukset": [],
+        }
+
+        enrich_items.enrich_oikaisut_korjaukset_for_export(today_items)
+
+        mock_group_items_by_type.assert_called_once_with(
+            [{"_id": "today-1"}, {"_id": "late-1"}]
+        )
+
+    @patch("stt.oikaisut_korjaukset_export.enrich_items._group_items_by_type")
+    @patch(_PREVIOUS_DAY_EVENING_ITEMS_PATCH)
+    def test_enrich_uses_previous_day_items_when_today_list_is_empty(
+        self,
+        mock_get_previous_day_evening_items,
+        mock_group_items_by_type,
+    ):
+        mock_get_previous_day_evening_items.return_value = [{"_id": "late-1"}]
+        mock_group_items_by_type.return_value = {
+            "oikaisut": [{"_id": "late-1"}],
+            "korjaukset": [],
+        }
+
+        result = enrich_items.enrich_oikaisut_korjaukset_for_export([])
+
+        self.assertEqual(
+            {"oikaisut": [{"_id": "late-1"}], "korjaukset": []},
+            result,
+        )
+        mock_group_items_by_type.assert_called_once_with([{"_id": "late-1"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a Mongo helper that resolves planning items linked to published oikaisu/korjaus content within a given firstpublished window.

Extend the oikaisut_korjaukset export enrichment to include items published on the previous day after 20:00 Helsinki time, deduplicated against the current day's planning rows.

Add focused tests for the Helsinki cutoff window and merge behavior.