### PR TITLE
[STT-1738] Configure `card_view` for the event and planning preview cards

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -251,6 +251,15 @@ module.exports = function (grunt) {
             {fieldId: 'state'},
           ],
         },
+        // Cards for linked planning items in the Event and Assignment previews
+        card_view: {
+          firstLine: [
+            {fieldId: 'priority', position: 'start', fieldOptions: {hideLabel: true}},
+            {fieldId: 'slugline', position: 'start'},
+            {fieldId: 'internalnote', position: 'start'},
+            {fieldId: 'coverages', position: 'end'},
+          ],
+        },
       },
       event_list_item: {
         firstLine: [
@@ -290,6 +299,16 @@ module.exports = function (grunt) {
             {fieldId: 'event_datetime', position: 'start'},
             {fieldId: 'name', position: 'start'},
             {fieldId: 'state', position: 'end'},
+          ],
+        },
+        // Cards for linked events in the Planning and Assignment previews
+        card_view: {
+          firstLine: [
+            {fieldId: 'event_datetime', position: 'start'},
+            {fieldId: 'name', position: 'start'},
+          ],
+          secondLine: [
+            {fieldId: 'location', position: 'start'},
           ],
         },
       },


### PR DESCRIPTION
## Purpose
Entity cards for linked items inside previews were reusing the full list-item config, which is far too dense for the narrow preview panel. `card_view` (added in superdesk/superdesk-planning#2925, backported to `release/3.5` in #2933) lets those cards carry their own field list. This sets it to what the customer asked for in the ticket comment.

## What has changed

- **Event card**, shown in planning previews: date and time, name, then location on its own line.
- **Planning card**, shown in event previews: priority badge, slugline, internal note icon, coverage icons.

Both leave out the category tags that the list rows carry. Two Finnish category names take up the whole width in a narrow panel and push the slugline out entirely.

This is how the cards look now:

<img width="349" height="116" alt="image" src="https://github.com/user-attachments/assets/741bfd59-932e-4d05-ab93-f8620c48876f" />

<img width="349" height="109" alt="image" src="https://github.com/user-attachments/assets/6831f981-8e01-4244-8819-86b943a8587a" />


## How to test
open a planning item with a linked event and look at the Related Events card, then open an event with linked planning items and look at those. The Events and Planning list rows should be unchanged, only `card_view` was added, the existing `firstLine` / `secondLine` / `compact_view` blocks are untouched.

[STT-1738]


[STT-1738]: https://sofab.atlassian.net/browse/STT-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ